### PR TITLE
API-5: Integrate Coveralls into CI Pipeline.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # trak-api
+
+[![Build Status](https://codebuild.eu-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoibDN4eUZpaXhQMkFQbmtEekdiZVZCSWM5aGFER2tRbVl2V2E4UEpvN29YTm5XUlMxTkovOXZxY2pmdnJwd0dHWkl4RzNrdE9URjFjOVVlcnp0dEFZRC9FPSIsIml2UGFyYW1ldGVyU3BlYyI6ImNPa1M1STRwOWJ5R251aGciLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=develop)](https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/projects/trak-api-development/history?region=eu-west-2&builds-state=%7B%22f%22%3A%7B%22text%22%3A%22%22%7D%2C%22s%22%3A%7B%7D%2C%22n%22%3A20%2C%22i%22%3A0%7D)
+[![Coverage Status](https://coveralls.io/repos/github/sparky-studios/trak-api/badge.svg?branch=develop)](https://coveralls.io/github/sparky-studios/trak-api?branch=develop)

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,5 +1,9 @@
 version: 0.2
 
+env:
+  parameter-store:
+    COVERALLS_TOKEN: "/trak-api/coveralls-token"
+
 phases:
   install:
     runtime-versions:
@@ -15,13 +19,15 @@ phases:
       - echo [INFO] ------------------------------------------------------------------------
       - echo [INFO] Building Trak API `date`
       - echo [INFO] ------------------------------------------------------------------------
+      - mvn compile
       - mvn test
   post_build:
     commands:
       - echo [INFO] ------------------------------------------------------------------------
       - echo [INFO] Completed Trak API `date`
       - echo [INFO] ------------------------------------------------------------------------
-      - mvn package
+      - mvn clean test jacoco:report coveralls:report -DrepoToken=$COVERALLS_TOKEN
+      - mvn package -DskipTests
 
 artifacts:
   files:

--- a/game-server/src/main/java/com/sparky/trak/game/server/assembler/DeveloperRepresentationModelAssembler.java
+++ b/game-server/src/main/java/com/sparky/trak/game/server/assembler/DeveloperRepresentationModelAssembler.java
@@ -29,7 +29,7 @@ public class DeveloperRepresentationModelAssembler implements SimpleRepresentati
             resource.add(linkTo(methodOn(DeveloperController.class).findById(content.getId()))
                     .withSelfRel());
 
-            resource.add(linkTo(methodOn(DeveloperController.class).findGamesFromDeveloperId(content.getId(), Pageable.unpaged(), gameDtoPagedResourcesAssembler))
+            resource.add(linkTo(methodOn(DeveloperController.class).findGamesByDeveloperId(content.getId(), Pageable.unpaged(), gameDtoPagedResourcesAssembler))
                     .withRel("games"));
         }
     }

--- a/game-server/src/main/java/com/sparky/trak/game/server/assembler/GameRepresentationModelAssembler.java
+++ b/game-server/src/main/java/com/sparky/trak/game/server/assembler/GameRepresentationModelAssembler.java
@@ -39,10 +39,10 @@ public class GameRepresentationModelAssembler implements SimpleRepresentationMod
             resource.add(linkTo(methodOn(GameController.class).findGenresByGameId(content.getId()))
                     .withRel("genres"));
 
-            resource.add(linkTo(methodOn(GameController.class).findDevelopersFromGameId(content.getId(), Pageable.unpaged(), developerDtoPagedResourcesAssembler))
+            resource.add(linkTo(methodOn(GameController.class).findDevelopersByGameId(content.getId(), Pageable.unpaged(), developerDtoPagedResourcesAssembler))
                     .withRel("developers"));
 
-            resource.add(linkTo(methodOn(GameController.class).findPublishersFromGameId(content.getId(), Pageable.unpaged(), publisherDtoPagedResourcesAssembler))
+            resource.add(linkTo(methodOn(GameController.class).findPublishersByGameId(content.getId(), Pageable.unpaged(), publisherDtoPagedResourcesAssembler))
                     .withRel("publishers"));
         }
     }

--- a/game-server/src/main/java/com/sparky/trak/game/server/assembler/PublisherRepresentationModelAssembler.java
+++ b/game-server/src/main/java/com/sparky/trak/game/server/assembler/PublisherRepresentationModelAssembler.java
@@ -29,7 +29,7 @@ public class PublisherRepresentationModelAssembler implements SimpleRepresentati
             resource.add(linkTo(methodOn(PublisherController.class).findById(content.getId()))
                     .withSelfRel());
 
-            resource.add(linkTo(methodOn(PublisherController.class).findGamesFromPublisherId(content.getId(), Pageable.unpaged(), gameDtoPagedResourcesAssembler))
+            resource.add(linkTo(methodOn(PublisherController.class).findGamesByPublisherId(content.getId(), Pageable.unpaged(), gameDtoPagedResourcesAssembler))
                     .withRel("games"));
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,8 @@
         <javax.validation.version>2.0.0.Final</javax.validation.version>
         <net.kaczmarzyk.specification.version>2.1.1</net.kaczmarzyk.specification.version>
         <org.apache.httpcomponents.version>4.5.3</org.apache.httpcomponents.version>
+        <org.eluder.coveralls.version>4.3.0</org.eluder.coveralls.version>
+        <org.jacoco.version>0.8.5</org.jacoco.version>
         <org.glassfish.javax.json.version>1.1.4</org.glassfish.javax.json.version>
         <org.mapstruct.version>1.3.1.Final</org.mapstruct.version>
         <org.projectlombok.version>1.18.12</org.projectlombok.version>
@@ -139,6 +141,26 @@
     </dependencyManagement>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>${org.eluder.coveralls.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${org.jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
         <pluginManagement>
             <plugins>
                 <plugin>


### PR DESCRIPTION
- Fixed compilation errors with representation model assemblers.
- Added the needed plugins for Jacoco and Coveralls code coverage.
- Added the coveralls token into the build pipeline, with the token being a secret stored in AWS parameter store.
- Added the uploading of the code coverage report to Coveralls.
- Added tags for build status and coverage into README.