### PR TITLE
API-6: Correct paging issues.

### DIFF
--- a/game-repository/src/main/java/com/sparky/trak/game/repository/GameRequestRepository.java
+++ b/game-repository/src/main/java/com/sparky/trak/game/repository/GameRequestRepository.java
@@ -1,7 +1,8 @@
 package com.sparky.trak.game.repository;
 
 import com.sparky.trak.game.domain.GameRequest;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
-public interface GameRequestRepository extends PagingAndSortingRepository<GameRequest, Long> {
+public interface GameRequestRepository extends PagingAndSortingRepository<GameRequest, Long>, JpaSpecificationExecutor<GameRequest> {
 }

--- a/game-repository/src/main/java/com/sparky/trak/game/repository/specification/GameRequestSpecification.java
+++ b/game-repository/src/main/java/com/sparky/trak/game/repository/specification/GameRequestSpecification.java
@@ -1,0 +1,18 @@
+package com.sparky.trak.game.repository.specification;
+
+import com.sparky.trak.game.domain.GameRequest;
+import net.kaczmarzyk.spring.data.jpa.domain.Equal;
+import net.kaczmarzyk.spring.data.jpa.domain.Like;
+import net.kaczmarzyk.spring.data.jpa.web.annotation.And;
+import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
+import org.springframework.data.jpa.domain.Specification;
+
+@And({
+        @Spec(path = "id", spec = Equal.class),
+        @Spec(path = "title", spec = Like.class),
+        @Spec(path = "completed", spec = Equal.class),
+        @Spec(path = "completedDate", params = "completed-date", spec = Equal.class),
+        @Spec(path = "userId", params = "user-id", spec = Equal.class)
+})
+public interface GameRequestSpecification extends Specification<GameRequest> {
+}

--- a/game-server/src/main/java/com/sparky/trak/game/server/controller/GameController.java
+++ b/game-server/src/main/java/com/sparky/trak/game/server/controller/GameController.java
@@ -12,13 +12,11 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.PagedResourcesAssembler;
-import org.springframework.hateoas.CollectionModel;
-import org.springframework.hateoas.EntityModel;
-import org.springframework.hateoas.MediaTypes;
-import org.springframework.hateoas.PagedModel;
+import org.springframework.hateoas.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import javax.json.JsonMergePatch;
 import java.util.List;
@@ -118,13 +116,21 @@ public class GameController {
     public PagedModel<EntityModel<PlatformDto>> findPlatformsByGameId(@PathVariable long id,
                                                                       @PageableDefault Pageable pageable,
                                                                       PagedResourcesAssembler<PlatformDto> pagedResourcesAssembler) {
+        // The self, next and prev links won't include query parameters if not built manually.
+        Link link = new Link(ServletUriComponentsBuilder.fromCurrentRequest().build()
+                .toUriString())
+                .withSelfRel();
+
         // Get the paged data from the service and convert into a list so it can be added to a page object.
         List<PlatformDto> platformDtos = StreamSupport.stream(platformService.findPlatformsByGameId(id, pageable).spliterator(), false)
                 .collect(Collectors.toList());
 
+        // Get the total number of entities that match the given criteria, dis-regarding page sizing.
+        long count = platformService.countPlatformsByGameId(id);
+
         // Wrap the page in a HATEOAS response.
         return pagedResourcesAssembler
-                .toModel(new PageImpl<>(platformDtos, pageable, platformDtos.size()), platformRepresentationModelAssembler);
+                .toModel(new PageImpl<>(platformDtos, pageable, count), platformRepresentationModelAssembler, link);
     }
 
     /**
@@ -142,14 +148,21 @@ public class GameController {
     public PagedModel<EntityModel<DeveloperDto>> findDevelopersByGameId(@PathVariable long id,
                                                                         @PageableDefault Pageable pageable,
                                                                         PagedResourcesAssembler<DeveloperDto> pagedResourcesAssembler) {
+        // The self, next and prev links won't include query parameters if not built manually.
+        Link link = new Link(ServletUriComponentsBuilder.fromCurrentRequest().build()
+                .toUriString())
+                .withSelfRel();
 
         // Get the paged data from the service and convert into a list so it can be added to a page object.
         List<DeveloperDto> developerDtos = StreamSupport.stream(developerService.findDevelopersByGameId(id, pageable).spliterator(), false)
                 .collect(Collectors.toList());
 
+        // Get the total number of entities that match the given criteria, dis-regarding page sizing.
+        long count = developerService.countDevelopersByGameId(id);
+
         // Wrap the page in a HATEOAS response.
         return pagedResourcesAssembler
-                .toModel(new PageImpl<>(developerDtos, pageable, developerDtos.size()), developerRepresentationModelAssembler);
+                .toModel(new PageImpl<>(developerDtos, pageable, count), developerRepresentationModelAssembler, link);
     }
 
     /**
@@ -167,14 +180,21 @@ public class GameController {
     public PagedModel<EntityModel<PublisherDto>> findPublishersByGameId(@PathVariable long id,
                                                                         @PageableDefault Pageable pageable,
                                                                         PagedResourcesAssembler<PublisherDto> pagedResourcesAssembler) {
+        // The self, next and prev links won't include query parameters if not built manually.
+        Link link = new Link(ServletUriComponentsBuilder.fromCurrentRequest().build()
+                .toUriString())
+                .withSelfRel();
 
         // Get the paged data from the service and convert into a list so it can be added to a page object.
         List<PublisherDto> publisherDtos = StreamSupport.stream(publisherService.findPublishersByGameId(id, pageable).spliterator(), false)
                 .collect(Collectors.toList());
 
+        // Get the total number of entities that match the given criteria, dis-regarding page sizing.
+        long count = publisherService.countPublishersByGameId(id);
+
         // Wrap the page in a HATEOAS response.
         return pagedResourcesAssembler
-                .toModel(new PageImpl<>(publisherDtos, pageable, publisherDtos.size()), publisherRepresentationModelAssembler);
+                .toModel(new PageImpl<>(publisherDtos, pageable, count), publisherRepresentationModelAssembler, link);
     }
 
     /**
@@ -197,12 +217,20 @@ public class GameController {
     public PagedModel<EntityModel<GameDto>> findAll(GameSpecification gameSpecification,
                                                     @PageableDefault Pageable pageable,
                                                     PagedResourcesAssembler<GameDto> pagedResourcesAssembler) {
+        // The self, next and prev links won't include query parameters if not built manually.
+        Link link = new Link(ServletUriComponentsBuilder.fromCurrentRequest().build()
+                .toUriString())
+                .withSelfRel();
+
         // Get the paged data from the service and convert into a list so it can be added to a page object.
         List<GameDto> gameDtos = StreamSupport.stream(gameService.findAll(gameSpecification, pageable).spliterator(), false)
                 .collect(Collectors.toList());
 
+        // Get the total number of entities that match the given criteria, dis-regarding page sizing.
+        long count = gameService.count(gameSpecification);
+
         // Wrap the page in a HATEOAS response.
-        return pagedResourcesAssembler.toModel(new PageImpl<>(gameDtos, pageable, gameDtos.size()), gameRepresentationModelAssembler);
+        return pagedResourcesAssembler.toModel(new PageImpl<>(gameDtos, pageable, count), gameRepresentationModelAssembler, link);
     }
 
     /**

--- a/game-server/src/main/java/com/sparky/trak/game/server/controller/GameUserEntryController.java
+++ b/game-server/src/main/java/com/sparky/trak/game/server/controller/GameUserEntryController.java
@@ -99,8 +99,11 @@ public class GameUserEntryController {
         List<GameUserEntryDto> gameUserEntryDtos = StreamSupport.stream(gameUserEntryService.findAll(gameUserEntrySpecification, pageable).spliterator(), false)
                 .collect(Collectors.toList());
 
+        // Get the total number of entities that match the given criteria, dis-regarding page sizing.
+        long count = gameUserEntryService.count(gameUserEntrySpecification);
+
         // Wrap the page in a HATEOAS response.
-        return pagedResourcesAssembler.toModel(new PageImpl<>(gameUserEntryDtos, pageable, gameUserEntryDtos.size()), gameUserEntryRepresentationModelAssembler, link);
+        return pagedResourcesAssembler.toModel(new PageImpl<>(gameUserEntryDtos, pageable, count), gameUserEntryRepresentationModelAssembler, link);
     }
 
     /**

--- a/game-service/src/main/java/com/sparky/trak/game/service/CompanyService.java
+++ b/game-service/src/main/java/com/sparky/trak/game/service/CompanyService.java
@@ -2,6 +2,7 @@ package com.sparky.trak.game.service;
 
 import com.sparky.trak.game.domain.Company;
 import com.sparky.trak.game.repository.specification.CompanySpecification;
+import com.sparky.trak.game.repository.specification.GameSpecification;
 import com.sparky.trak.game.service.dto.CompanyDto;
 import org.springframework.data.domain.Pageable;
 
@@ -61,6 +62,16 @@ public interface CompanyService {
      * @return An {@link Iterable} of relevant queried {@link CompanyDto} instances.
      */
     Iterable<CompanyDto> findAll(CompanySpecification companySpecification, Pageable pageable);
+
+    /**
+     * Retrieves the total number of rows that match the criteria specified within the {@link CompanySpecification}. The specification
+     * provided must be a valid instance, if <code>null</code> is provided, a {@link NullPointerException} will be thrown to the callee.
+     *
+     * @param companySpecification The {@link CompanySpecification} criteria to count the results for.
+     *
+     * @return The total number of rows that matches the given criteria.
+     */
+    long count(CompanySpecification companySpecification);
 
     /**
      * Given a {@link CompanyDto} instance, the service will attempt to the update the persisted data which matches the given {@link CompanyDto}

--- a/game-service/src/main/java/com/sparky/trak/game/service/DeveloperService.java
+++ b/game-service/src/main/java/com/sparky/trak/game/service/DeveloperService.java
@@ -62,6 +62,17 @@ public interface DeveloperService {
     Iterable<DeveloperDto> findDevelopersByGameId(long gameId, Pageable pageable);
 
     /**
+     * Given the ID of a {@link GameDto}, this method will retrieve the total count for how many {@link DeveloperDto}'s have an association
+     * to the given {@link GameDto}. If the ID provided does not map to any {@link GameDto}, {@link javax.persistence.EntityNotFoundException}
+     * will be thrown.
+     *
+     * @param gameId The ID of the {@link GameDto} to retrieve the total count of {@link DeveloperDto} entries for.
+     *
+     * @return The total count of {@link DeveloperDto}'s associated with the given {@link GameDto}.
+     */
+    long countDevelopersByGameId(long gameId);
+
+    /**
      * This method will retrieve an {@link Iterable} of {@link DeveloperDto} with a response size specified by the {@link Pageable}. The
      * results can be queried and filtered by utilising the exposed specifications on the {@link DeveloperSpecification} object. If the response
      * from the specifications is that none match, an empty {@link Iterable} will be returned.
@@ -75,6 +86,16 @@ public interface DeveloperService {
      * @return An {@link Iterable} of relevant queried {@link DeveloperDto} instances.
      */
     Iterable<DeveloperDto> findAll(DeveloperSpecification developerSpecification, Pageable pageable);
+
+    /**
+     * Retrieves the total number of rows that match the criteria specified within the {@link DeveloperSpecification}. The specification
+     * provided must be a valid instance, if <code>null</code> is provided, a {@link NullPointerException} will be thrown to the callee.
+     *
+     * @param developerSpecification The {@link DeveloperSpecification} criteria to count the results for.
+     *
+     * @return The total number of rows that matches the given criteria.
+     */
+    long count(DeveloperSpecification developerSpecification);
 
     /**
      * Given a {@link DeveloperDto} instance, the service will attempt to the update the persisted data which matches the given {@link DeveloperDto}

--- a/game-service/src/main/java/com/sparky/trak/game/service/GameRequestService.java
+++ b/game-service/src/main/java/com/sparky/trak/game/service/GameRequestService.java
@@ -1,6 +1,9 @@
 package com.sparky.trak.game.service;
 
 import com.sparky.trak.game.domain.GameRequest;
+import com.sparky.trak.game.repository.specification.DeveloperSpecification;
+import com.sparky.trak.game.repository.specification.GameRequestSpecification;
+import com.sparky.trak.game.service.dto.DeveloperDto;
 import com.sparky.trak.game.service.dto.GameRequestDto;
 import org.springframework.data.domain.Pageable;
 
@@ -51,14 +54,29 @@ public interface GameRequestService {
     GameRequestDto findById(long id);
 
     /**
-     * This method will retrieve an {@link Iterable} of {@link GameRequestDto} with a response size specified by the {@link Pageable}. The response
-     * can be sorted by relying on the default behavior provided by the {@link Pageable} interface.
+     * This method will retrieve an {@link Iterable} of {@link GameRequestDto} with a response size specified by the {@link Pageable}. The
+     * results can be queried and filtered by utilising the exposed specifications on the {@link GameRequestSpecification} object. If the response
+     * from the specifications is that none match, an empty {@link Iterable} will be returned.
      *
+     * The {@link GameRequestSpecification} argument can be omitted and is optional, however if the callee provides <code>null</code> for the
+     * {@link Pageable}, an exception will be thrown.
+     *
+     * @param gameRequestSpecification The {@link GameRequestSpecification} to filter the query by.
      * @param pageable The size and page of data to return.
      *
      * @return An {@link Iterable} of relevant queried {@link GameRequestDto} instances.
      */
-    Iterable<GameRequestDto> findAll(Pageable pageable);
+    Iterable<GameRequestDto> findAll(GameRequestSpecification gameRequestSpecification, Pageable pageable);
+
+    /**
+     * Retrieves the total number of rows that match the criteria specified within the {@link GameRequestSpecification}. The specification
+     * provided must be a valid instance, if <code>null</code> is provided, a {@link NullPointerException} will be thrown to the callee.
+     *
+     * @param gameRequestSpecification The {@link GameRequestSpecification} criteria to count the results for.
+     *
+     * @return The total number of rows that matches the given criteria.
+     */
+    long count(GameRequestSpecification gameRequestSpecification);
 
     /**
      * Given a {@link GameRequestDto} instance, the service will attempt to the update the persisted data which matches the given {@link GameRequestDto}

--- a/game-service/src/main/java/com/sparky/trak/game/service/GameService.java
+++ b/game-service/src/main/java/com/sparky/trak/game/service/GameService.java
@@ -2,6 +2,7 @@ package com.sparky.trak.game.service;
 
 import com.sparky.trak.game.domain.*;
 import com.sparky.trak.game.repository.specification.GameSpecification;
+import com.sparky.trak.game.repository.specification.GameUserEntrySpecification;
 import com.sparky.trak.game.service.dto.CompanyDto;
 import com.sparky.trak.game.service.dto.DeveloperDto;
 import com.sparky.trak.game.service.dto.GameDto;
@@ -64,6 +65,17 @@ public interface GameService {
     Iterable<GameDto> findGamesByGenreId(long genreId, Pageable pageable);
 
     /**
+     * Given the ID of a {@link Genre}, this method will retrieve the total count for how many {@link GameDto}'s have an association
+     * to the given {@link Genre}. If the ID provided does not map to any {@link Genre}, {@link javax.persistence.EntityNotFoundException}
+     * will be thrown.
+     *
+     * @param genreId The ID of the {@link Genre} to retrieve the total count of {@link Game} entries for.
+     *
+     * @return The total count of {@link GameDto}'s associated with the given {@link Genre}.
+     */
+    long countGamesByGenreId(long genreId);
+
+    /**
      * Given the ID of a {@link Platform}, this method will retrieve a {@link Page} of {@link Game}s that are associated with
      * the given {@link Platform}. If the ID provided does not map to any {@link Platform}, a {@link javax.persistence.EntityNotFoundException}
      * will be thrown. If there are no {@link Game}s associated with the {@link Platform}, an empty {@link Iterable} will be returned.
@@ -74,6 +86,17 @@ public interface GameService {
      * @return A page of {@link GameDto}s that are mapped with the given {@link Platform}.
      */
     Iterable<GameDto> findGamesByPlatformId(long platformId, Pageable pageable);
+
+    /**
+     * Given the ID of a {@link Platform}, this method will retrieve the total count for how many {@link GameDto}'s have an association
+     * to the given {@link Platform}. If the ID provided does not map to any {@link Platform}, {@link javax.persistence.EntityNotFoundException}
+     * will be thrown.
+     *
+     * @param platformId The ID of the {@link Platform} to retrieve the total count of {@link Game} entries for.
+     *
+     * @return The total count of {@link GameDto}'s associated with the given {@link Platform}.
+     */
+    long countGamesByPlatformId(long platformId);
 
     /**
      * Given the ID of a {@link Developer}, this method will retrieve a {@link Page} of {@link Game}s that are associated with
@@ -88,6 +111,17 @@ public interface GameService {
     Iterable<GameDto> findGamesByDeveloperId(long developerId, Pageable pageable);
 
     /**
+     * Given the ID of a {@link Developer}, this method will retrieve the total count for how many {@link GameDto}'s have an association
+     * to the given {@link Developer}. If the ID provided does not map to any {@link Developer}, {@link javax.persistence.EntityNotFoundException}
+     * will be thrown.
+     *
+     * @param developerId The ID of the {@link Developer} to retrieve the total count of {@link Game} entries for.
+     *
+     * @return The total count of {@link GameDto}'s associated with the given {@link Developer}.
+     */
+    long countGamesByDeveloperId(long developerId);
+
+    /**
      * Given the ID of a {@link Publisher}, this method will retrieve a {@link Page} of {@link Game}s that are associated with
      * the given {@link PublisherDto}. If the ID provided does not map to any {@link DeveloperDto}, a {@link javax.persistence.EntityNotFoundException}
      * will be thrown. If there are no {@link Game}s associated with the {@link PublisherDto}, an empty {@link Iterable} will be returned.
@@ -98,6 +132,17 @@ public interface GameService {
      * @return A page of {@link GameDto}s that are mapped with the given {@link Publisher} entity.
      */
     Iterable<GameDto> findGamesByPublisherId(long publisherId, Pageable pageable);
+
+    /**
+     * Given the ID of a {@link Publisher}, this method will retrieve the total count for how many {@link GameDto}'s have an association
+     * to the given {@link Publisher}. If the ID provided does not map to any {@link Publisher}, {@link javax.persistence.EntityNotFoundException}
+     * will be thrown.
+     *
+     * @param publisherId The ID of the {@link Publisher} to retrieve the total count of {@link Game} entries for.
+     *
+     * @return The total count of {@link GameDto}'s associated with the given {@link Publisher}.
+     */
+    long countGamesByPublisherId(long publisherId);
 
     /**
      * Retrieves all of the {@link Game} entities stored within the persistence layer. This method should not be used within a live
@@ -122,6 +167,16 @@ public interface GameService {
      * @return An {@link Iterable} of relevant queried {@link GameDto} instances.
      */
     Iterable<GameDto> findAll(GameSpecification gameSpecification, Pageable pageable);
+
+    /**
+     * Retrieves the total number of rows that match the criteria specified within the {@link GameSpecification}. The specification
+     * provided must be a valid instance, if <code>null</code> is provided, a {@link NullPointerException} will be thrown to the callee.
+     *
+     * @param gameSpecification The {@link GameSpecification} criteria to count the results for.
+     *
+     * @return The total number of rows that matches the given criteria.
+     */
+    long count(GameSpecification gameSpecification);
 
     /**
      * Given a {@link GameDto} instance, the service will attempt to the update the persisted data which matches the given {@link GameDto}

--- a/game-service/src/main/java/com/sparky/trak/game/service/GameUserEntryService.java
+++ b/game-service/src/main/java/com/sparky/trak/game/service/GameUserEntryService.java
@@ -56,6 +56,16 @@ public interface GameUserEntryService {
     Iterable<GameUserEntryDto> findAll(GameUserEntrySpecification gameUserEntrySpecification, Pageable pageable);
 
     /**
+     * Retrieves the total number of rows that match the criteria specified within the {@link GameUserEntrySpecification}. The specification
+     * provided must be a valid instance, if <code>null</code> is provided, a {@link NullPointerException} will be thrown to the callee.
+     *
+     * @param gameUserEntrySpecification The {@link GameUserEntrySpecification} criteria to count the results for.
+     *
+     * @return The total number of rows that matches the given criteria.
+     */
+    long count(GameUserEntrySpecification gameUserEntrySpecification);
+
+    /**
      * Given a {@link GameUserEntryDto} instance, the service will attempt to the update the persisted data which matches the given {@link GameUserEntryDto}
      * in the underlying persistence layer. If the {@link GameUserEntryDto} supplied contains an ID that doesn't match any existing entities, then
      * the update will fail and a {@link javax.persistence.EntityNotFoundException} will be thrown. If persistence succeeds, the relevant

--- a/game-service/src/main/java/com/sparky/trak/game/service/GenreService.java
+++ b/game-service/src/main/java/com/sparky/trak/game/service/GenreService.java
@@ -92,6 +92,16 @@ public interface GenreService {
     Iterable<GenreDto> findAll(GenreSpecification genreSpecification, Pageable pageable);
 
     /**
+     * Retrieves the total number of rows that match the criteria specified within the {@link GenreSpecification}. The specification
+     * provided must be a valid instance, if <code>null</code> is provided, a {@link NullPointerException} will be thrown to the callee.
+     *
+     * @param genreSpecification The {@link GenreSpecification} criteria to count the results for.
+     *
+     * @return The total number of rows that matches the given criteria.
+     */
+    long count(GenreSpecification genreSpecification);
+
+    /**
      * Given a {@link GenreDto} instance, the service will attempt to the update the persisted data which matches the given {@link GenreDto}
      * in the underlying persistence layer. If the {@link GenreDto} supplied contains an ID that doesn't match any existing entities, then
      * the update will fail and a {@link javax.persistence.EntityNotFoundException} will be thrown. If persistence succeeds, the relevant

--- a/game-service/src/main/java/com/sparky/trak/game/service/PlatformService.java
+++ b/game-service/src/main/java/com/sparky/trak/game/service/PlatformService.java
@@ -2,8 +2,8 @@ package com.sparky.trak.game.service;
 
 import com.sparky.trak.game.domain.Platform;
 import com.sparky.trak.game.repository.specification.PlatformSpecification;
-import com.sparky.trak.game.service.dto.PlatformDto;
 import com.sparky.trak.game.service.dto.GameDto;
+import com.sparky.trak.game.service.dto.PlatformDto;
 import org.springframework.data.domain.Pageable;
 
 import javax.json.JsonMergePatch;
@@ -69,6 +69,17 @@ public interface PlatformService {
     Iterable<PlatformDto> findPlatformsByGameId(long gameId, Pageable pageable);
 
     /**
+     * Given the ID of a {@link GameDto}, this method will retrieve the total count for how many {@link PlatformDto}'s have an association
+     * to the given {@link GameDto}. If the ID provided does not map to any {@link GameDto}, {@link javax.persistence.EntityNotFoundException}
+     * will be thrown.
+     *
+     * @param gameId The ID of the {@link GameDto} to retrieve the total count of {@link PlatformDto} entries for.
+     *
+     * @return The total count of {@link PlatformDto}'s associated with the given {@link GameDto}.
+     */
+    long countPlatformsByGameId(long gameId);
+
+    /**
      * This method will retrieve an {@link Iterable} of {@link PlatformDto} with a response size specified by the {@link Pageable}. The
      * results can be queried and filtered by utilising the exposed specifications on the {@link PlatformSpecification} object. If the response
      * from the specifications is that none match, an empty {@link Iterable} will be returned.
@@ -82,6 +93,16 @@ public interface PlatformService {
      * @return An {@link Iterable} of relevant queried {@link PlatformDto} instances.
      */
     Iterable<PlatformDto> findAll(PlatformSpecification platformSpecification, Pageable pageable);
+
+    /**
+     * Retrieves the total number of rows that match the criteria specified within the {@link PlatformSpecification}. The specification
+     * provided must be a valid instance, if <code>null</code> is provided, a {@link NullPointerException} will be thrown to the callee.
+     *
+     * @param platformSpecification The {@link PlatformSpecification} criteria to count the results for.
+     *
+     * @return The total number of rows that matches the given criteria.
+     */
+    long count(PlatformSpecification platformSpecification);
 
     /**
      * Given a {@link PlatformDto} instance, the service will attempt to the update the persisted data which matches the given {@link PlatformDto}

--- a/game-service/src/main/java/com/sparky/trak/game/service/PublisherService.java
+++ b/game-service/src/main/java/com/sparky/trak/game/service/PublisherService.java
@@ -1,7 +1,9 @@
 package com.sparky.trak.game.service;
 
 import com.sparky.trak.game.domain.Publisher;
+import com.sparky.trak.game.repository.specification.PlatformSpecification;
 import com.sparky.trak.game.repository.specification.PublisherSpecification;
+import com.sparky.trak.game.service.dto.DeveloperDto;
 import com.sparky.trak.game.service.dto.GameDto;
 import com.sparky.trak.game.service.dto.PublisherDto;
 import org.springframework.data.domain.Page;
@@ -62,6 +64,17 @@ public interface PublisherService {
     Iterable<PublisherDto> findPublishersByGameId(long gameId, Pageable pageable);
 
     /**
+     * Given the ID of a {@link GameDto}, this method will retrieve the total count for how many {@link PublisherDto}'s have an association
+     * to the given {@link GameDto}. If the ID provided does not map to any {@link GameDto}, {@link javax.persistence.EntityNotFoundException}
+     * will be thrown.
+     *
+     * @param gameId The ID of the {@link GameDto} to retrieve the total count of {@link PublisherDto} entries for.
+     *
+     * @return The total count of {@link PublisherDto}'s associated with the given {@link GameDto}.
+     */
+    long countPublishersByGameId(long gameId);
+
+    /**
      * This method will retrieve an {@link Iterable} of {@link PublisherDto} with a response size specified by the {@link Pageable}. The
      * results can be queried and filtered by utilising the exposed specifications on the {@link PublisherSpecification} object. If the response
      * from the specifications is that none match, an empty {@link Iterable} will be returned.
@@ -75,6 +88,16 @@ public interface PublisherService {
      * @return An {@link Iterable} of relevant queried {@link PublisherDto} instances.
      */
     Iterable<PublisherDto> findAll(PublisherSpecification publisherSpecification, Pageable pageable);
+
+    /**
+     * Retrieves the total number of rows that match the criteria specified within the {@link PublisherSpecification}. The specification
+     * provided must be a valid instance, if <code>null</code> is provided, a {@link NullPointerException} will be thrown to the callee.
+     *
+     * @param publisherSpecification The {@link PublisherSpecification} criteria to count the results for.
+     *
+     * @return The total number of rows that matches the given criteria.
+     */
+    long count(PublisherSpecification publisherSpecification);
 
     /**
      * Given a {@link PublisherDto} instance, the service will attempt to the update the persisted data which matches the given {@link PublisherDto}

--- a/game-service/src/main/java/com/sparky/trak/game/service/impl/CompanyServiceImpl.java
+++ b/game-service/src/main/java/com/sparky/trak/game/service/impl/CompanyServiceImpl.java
@@ -58,6 +58,13 @@ public class CompanyServiceImpl implements CompanyService {
     }
 
     @Override
+    public long count(CompanySpecification companySpecification) {
+        Objects.requireNonNull(companySpecification);
+
+        return companyRepository.count(companySpecification);
+    }
+
+    @Override
     public CompanyDto update(CompanyDto companyDto) {
         Objects.requireNonNull(companyDto);
 

--- a/game-service/src/main/java/com/sparky/trak/game/service/impl/DeveloperServiceImpl.java
+++ b/game-service/src/main/java/com/sparky/trak/game/service/impl/DeveloperServiceImpl.java
@@ -68,11 +68,31 @@ public class DeveloperServiceImpl implements DeveloperService {
     }
 
     @Override
+    public long countDevelopersByGameId(long gameId) {
+        if (!gameRepository.existsById(gameId)) {
+            String errorMessage = messageSource
+                    .getMessage("game.exception.not-found", new Object[] { gameId }, LocaleContextHolder.getLocale());
+
+            throw new EntityNotFoundException((errorMessage));
+        }
+
+        return gameDeveloperXrefRepository
+                .count(((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("gameId"), gameId)));
+    }
+
+    @Override
     public Iterable<DeveloperDto> findAll(DeveloperSpecification developerSpecification, Pageable pageable) {
         Objects.requireNonNull(pageable);
 
         return developerRepository.findAll(developerSpecification, pageable)
                 .map(developerMapper::developerToDeveloperDto);
+    }
+
+    @Override
+    public long count(DeveloperSpecification developerSpecification) {
+        Objects.requireNonNull(developerSpecification);
+
+        return developerRepository.count(developerSpecification);
     }
 
     @Override

--- a/game-service/src/main/java/com/sparky/trak/game/service/impl/GameRequestServiceImpl.java
+++ b/game-service/src/main/java/com/sparky/trak/game/service/impl/GameRequestServiceImpl.java
@@ -2,6 +2,7 @@ package com.sparky.trak.game.service.impl;
 
 import com.sparky.trak.game.domain.GameRequest;
 import com.sparky.trak.game.repository.GameRequestRepository;
+import com.sparky.trak.game.repository.specification.GameRequestSpecification;
 import com.sparky.trak.game.service.AuthenticationService;
 import com.sparky.trak.game.service.GameRequestService;
 import com.sparky.trak.game.service.PatchService;
@@ -61,11 +62,18 @@ public class GameRequestServiceImpl implements GameRequestService {
     }
 
     @Override
-    public Iterable<GameRequestDto> findAll(Pageable pageable) {
+    public Iterable<GameRequestDto> findAll(GameRequestSpecification gameRequestSpecification, Pageable pageable) {
         Objects.requireNonNull(pageable);
 
-        return gameRequestRepository.findAll(pageable)
+        return gameRequestRepository.findAll(gameRequestSpecification, pageable)
                 .map(gameRequestMapper::gameRequestToGameRequestDto);
+    }
+
+    @Override
+    public long count(GameRequestSpecification gameRequestSpecification) {
+        Objects.requireNonNull(gameRequestSpecification);
+
+        return gameRequestRepository.count(gameRequestSpecification);
     }
 
     @Override

--- a/game-service/src/main/java/com/sparky/trak/game/service/impl/GameServiceImpl.java
+++ b/game-service/src/main/java/com/sparky/trak/game/service/impl/GameServiceImpl.java
@@ -74,6 +74,19 @@ public class GameServiceImpl implements GameService {
     }
 
     @Override
+    public long countGamesByGenreId(long genreId) {
+        if (!genreRepository.existsById(genreId)) {
+            String errorMessage = messageSource
+                    .getMessage("genre.exception.not-found", new Object[] { genreId }, LocaleContextHolder.getLocale());
+
+            throw new EntityNotFoundException((errorMessage));
+        }
+
+        return gameGenreXrefRepository
+                .count((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("genreId"), genreId));
+    }
+
+    @Override
     public Iterable<GameDto> findGamesByPlatformId(long platformId, Pageable pageable) {
         if (!platformRepository.existsById(platformId)) {
             String errorMessage = messageSource
@@ -85,6 +98,19 @@ public class GameServiceImpl implements GameService {
         return gamePlatformXrefRepository
                 .findAll(((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("platformId"), platformId)), pageable)
                 .map(xref -> gameMapper.gameToGameDto(xref.getGame()));
+    }
+
+    @Override
+    public long countGamesByPlatformId(long platformId) {
+        if (!platformRepository.existsById(platformId)) {
+            String errorMessage = messageSource
+                    .getMessage("platform.exception.not-found", new Object[] { platformId }, LocaleContextHolder.getLocale());
+
+            throw new EntityNotFoundException((errorMessage));
+        }
+
+        return gamePlatformXrefRepository
+                .count((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("platformId"), platformId));
     }
 
     @Override
@@ -102,6 +128,19 @@ public class GameServiceImpl implements GameService {
     }
 
     @Override
+    public long countGamesByDeveloperId(long developerId) {
+        if (!developerRepository.existsById(developerId)) {
+            String errorMessage = messageSource
+                    .getMessage("developer.exception.not-found", new Object[] { developerId }, LocaleContextHolder.getLocale());
+
+            throw new EntityNotFoundException((errorMessage));
+        }
+
+        return gameDeveloperXrefRepository
+                .count((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("developerId"), developerId));
+    }
+
+    @Override
     public Iterable<GameDto> findGamesByPublisherId(long publisherId, Pageable pageable) {
         if (!publisherRepository.existsById(publisherId)) {
             String errorMessage = messageSource
@@ -113,6 +152,19 @@ public class GameServiceImpl implements GameService {
         return gamePublisherXrefRepository
                 .findAll(((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("publisherId"), publisherId)), pageable)
                 .map(xref -> gameMapper.gameToGameDto(xref.getGame()));
+    }
+
+    @Override
+    public long countGamesByPublisherId(long publisherId) {
+        if (!publisherRepository.existsById(publisherId)) {
+            String errorMessage = messageSource
+                    .getMessage("publisher.exception.not-found", new Object[] { publisherId }, LocaleContextHolder.getLocale());
+
+            throw new EntityNotFoundException((errorMessage));
+        }
+
+        return gamePublisherXrefRepository
+                .count((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("publisherId"), publisherId));
     }
 
     @Override
@@ -128,6 +180,13 @@ public class GameServiceImpl implements GameService {
 
         return gameRepository.findAll(gameSpecification, pageable)
                 .map(gameMapper::gameToGameDto);
+    }
+
+    @Override
+    public long count(GameSpecification gameSpecification) {
+        Objects.requireNonNull(gameSpecification);
+
+        return gameRepository.count(gameSpecification);
     }
 
     @Override

--- a/game-service/src/main/java/com/sparky/trak/game/service/impl/GameUserEntryServiceImpl.java
+++ b/game-service/src/main/java/com/sparky/trak/game/service/impl/GameUserEntryServiceImpl.java
@@ -18,7 +18,6 @@ import org.springframework.stereotype.Service;
 import javax.json.JsonMergePatch;
 import javax.persistence.EntityExistsException;
 import javax.persistence.EntityNotFoundException;
-import javax.swing.text.html.Option;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -70,6 +69,13 @@ public class GameUserEntryServiceImpl implements GameUserEntryService {
         return StreamSupport.stream(gameUserEntryRepository.findAll(gameUserEntrySpecification, pageable).spliterator(), false)
                 .map(gameUserEntryMapper::gameUserEntryToGameUserEntryDto)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public long count(GameUserEntrySpecification gameUserEntrySpecification) {
+        Objects.requireNonNull(gameUserEntrySpecification);
+
+        return gameUserEntryRepository.count(gameUserEntrySpecification);
     }
 
     @Override

--- a/game-service/src/main/java/com/sparky/trak/game/service/impl/GenreServiceImpl.java
+++ b/game-service/src/main/java/com/sparky/trak/game/service/impl/GenreServiceImpl.java
@@ -89,6 +89,13 @@ public class GenreServiceImpl implements GenreService {
 }
 
     @Override
+    public long count(GenreSpecification genreSpecification) {
+        Objects.requireNonNull(genreSpecification);
+
+        return genreRepository.count(genreSpecification);
+    }
+
+    @Override
     public GenreDto update(GenreDto genreDto) {
         Objects.requireNonNull(genreDto);
 

--- a/game-service/src/main/java/com/sparky/trak/game/service/impl/PlatformServiceImpl.java
+++ b/game-service/src/main/java/com/sparky/trak/game/service/impl/PlatformServiceImpl.java
@@ -1,11 +1,11 @@
 package com.sparky.trak.game.service.impl;
 
-import com.sparky.trak.game.repository.PlatformRepository;
 import com.sparky.trak.game.repository.GamePlatformXrefRepository;
 import com.sparky.trak.game.repository.GameRepository;
+import com.sparky.trak.game.repository.PlatformRepository;
 import com.sparky.trak.game.repository.specification.PlatformSpecification;
-import com.sparky.trak.game.service.PlatformService;
 import com.sparky.trak.game.service.PatchService;
+import com.sparky.trak.game.service.PlatformService;
 import com.sparky.trak.game.service.dto.PlatformDto;
 import com.sparky.trak.game.service.mapper.PlatformMapper;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Service;
 import javax.json.JsonMergePatch;
 import javax.persistence.EntityExistsException;
 import javax.persistence.EntityNotFoundException;
-import java.util.Comparator;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -78,11 +77,31 @@ public class PlatformServiceImpl implements PlatformService {
     }
 
     @Override
+    public long countPlatformsByGameId(long gameId) {
+        if (!gameRepository.existsById(gameId)) {
+            String errorMessage = messageSource
+                    .getMessage("game.exception.not-found", new Object[] { gameId }, LocaleContextHolder.getLocale());
+
+            throw new EntityNotFoundException((errorMessage));
+        }
+
+        return gamePlatformXrefRepository
+                .count(((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("gameId"), gameId)));
+    }
+
+    @Override
     public Iterable<PlatformDto> findAll(PlatformSpecification platformSpecification, Pageable pageable) {
         Objects.requireNonNull(pageable);
 
         return platformRepository.findAll(platformSpecification, pageable)
                 .map(platformMapper::platformToPlatformDto);
+    }
+
+    @Override
+    public long count(PlatformSpecification platformSpecification) {
+        Objects.requireNonNull(platformSpecification);
+
+        return platformRepository.count(platformSpecification);
     }
 
     @Override

--- a/game-service/src/main/java/com/sparky/trak/game/service/impl/PublisherServiceImpl.java
+++ b/game-service/src/main/java/com/sparky/trak/game/service/impl/PublisherServiceImpl.java
@@ -68,11 +68,31 @@ public class PublisherServiceImpl implements PublisherService {
     }
 
     @Override
+    public long countPublishersByGameId(long gameId) {
+        if (!gameRepository.existsById(gameId)) {
+            String errorMessage = messageSource
+                    .getMessage("game.exception.not-found", new Object[] { gameId }, LocaleContextHolder.getLocale());
+
+            throw new EntityNotFoundException((errorMessage));
+        }
+
+        return gamePublisherXrefRepository
+                .count((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("gameId"), gameId));
+    }
+
+    @Override
     public Iterable<PublisherDto> findAll(PublisherSpecification publisherSpecification, Pageable pageable) {
         Objects.requireNonNull(pageable);
 
         return publisherRepository.findAll(publisherSpecification, pageable)
                 .map(publisherMapper::publisherToPublisherDto);
+    }
+
+    @Override
+    public long count(PublisherSpecification publisherSpecification) {
+        Objects.requireNonNull(publisherSpecification);
+
+        return publisherRepository.count(publisherSpecification);
     }
 
     @Override

--- a/game-service/src/test/java/com/sparky/trak/game/service/impl/CompanyServiceImplTest.java
+++ b/game-service/src/test/java/com/sparky/trak/game/service/impl/CompanyServiceImplTest.java
@@ -155,6 +155,26 @@ public class CompanyServiceImplTest {
     }
 
     @Test
+    public void count_withNullCompanySpecification_throwsNullPointerException() {
+        // Assert
+        Assertions.assertThrows(NullPointerException.class, () -> companyService.count(null));
+    }
+
+    @Test
+    public void count_withValidCompanySpecification_invokesCount() {
+        // Arrange
+        Mockito.when(companyRepository.count(ArgumentMatchers.any()))
+                .thenReturn(0L);
+
+        // Act
+        companyService.count(Mockito.mock(CompanySpecification.class));
+
+        // Assert
+        Mockito.verify(companyRepository, Mockito.atMostOnce())
+                .count(Mockito.any());
+    }
+
+    @Test
     public void update_withNullCompanyDto_throwsNullPointerException() {
         // Assert
         Assertions.assertThrows(NullPointerException.class, () -> companyService.update(null));

--- a/game-service/src/test/java/com/sparky/trak/game/service/impl/DeveloperServiceImplTest.java
+++ b/game-service/src/test/java/com/sparky/trak/game/service/impl/DeveloperServiceImplTest.java
@@ -181,6 +181,36 @@ public class DeveloperServiceImplTest {
     }
 
     @Test
+    public void countDevelopersByGameId_withNonExistentGame_throwsEntityNotFoundException() {
+        // Arrange
+        Mockito.when(gameRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(false);
+
+        Mockito.when(messageSource.getMessage(ArgumentMatchers.anyString(), ArgumentMatchers.any(Object[].class), ArgumentMatchers.any(Locale.class)))
+                .thenReturn("");
+
+        // Assert
+        Assertions.assertThrows(EntityNotFoundException.class, () -> developerService.countDevelopersByGameId(0L));
+    }
+
+    @Test
+    public void countDevelopersByGameId_withGame_invokesGameDeveloperXrefRepository() {
+        // Arrange
+        Mockito.when(gameRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(true);
+
+        Mockito.when(gameDeveloperXrefRepository.count(ArgumentMatchers.any()))
+            .thenReturn(0L);
+
+        // Act
+        developerService.countDevelopersByGameId(0L);
+
+        // Assert
+        Mockito.verify(gameDeveloperXrefRepository, Mockito.atMostOnce())
+                .count(ArgumentMatchers.any());
+    }
+
+    @Test
     public void findAll_withNullPageable_throwsNullPointerException() {
         // Assert
         Assertions.assertThrows(NullPointerException.class, () -> developerService.findAll(Mockito.mock(DeveloperSpecification.class), null));
@@ -220,6 +250,26 @@ public class DeveloperServiceImplTest {
 
         // Assert
         Assertions.assertFalse(result.isEmpty(), "The result shouldn't be empty if the repository returned companies.");
+    }
+
+    @Test
+    public void count_withNullDeveloperSpecification_throwsNullPointerException() {
+        // Assert
+        Assertions.assertThrows(NullPointerException.class, () -> developerService.count(null));
+    }
+
+    @Test
+    public void count_withValidDeveloperSpecification_invokesCount() {
+        // Arrange
+        Mockito.when(developerRepository.count(ArgumentMatchers.any()))
+                .thenReturn(0L);
+
+        // Act
+        developerService.count(Mockito.mock(DeveloperSpecification.class));
+
+        // Assert
+        Mockito.verify(developerRepository, Mockito.atMostOnce())
+                .count(Mockito.any());
     }
 
     @Test

--- a/game-service/src/test/java/com/sparky/trak/game/service/impl/GameRequestServiceImplTest.java
+++ b/game-service/src/test/java/com/sparky/trak/game/service/impl/GameRequestServiceImplTest.java
@@ -2,6 +2,7 @@ package com.sparky.trak.game.service.impl;
 
 import com.sparky.trak.game.domain.GameRequest;
 import com.sparky.trak.game.repository.GameRequestRepository;
+import com.sparky.trak.game.repository.specification.GameRequestSpecification;
 import com.sparky.trak.game.service.AuthenticationService;
 import com.sparky.trak.game.service.PatchService;
 import com.sparky.trak.game.service.dto.GameRequestDto;
@@ -155,19 +156,20 @@ public class GameRequestServiceImplTest {
     @Test
     public void findAll_withNullPageable_throwsNullPointerException() {
         // Assert
-        Assertions.assertThrows(NullPointerException.class, () -> gameRequestService.findAll(null));
+        Assertions.assertThrows(NullPointerException.class, () -> gameRequestService.findAll(Mockito.mock(GameRequestSpecification.class), null));
     }
 
     @Test
     public void findAll_withNoGameRequests_returnsEmptyList() {
         // Arrange
-        Mockito.when(gameRequestRepository.findAll(ArgumentMatchers.any(Pageable.class)))
+        Mockito.when(gameRequestRepository.findAll(ArgumentMatchers.any(GameRequestSpecification.class), ArgumentMatchers.any(Pageable.class)))
                 .thenReturn(Page.empty());
 
+        GameRequestSpecification gameRequestSpecification = Mockito.mock(GameRequestSpecification.class);
         Pageable pageable = Mockito.mock(Pageable.class);
 
         // Act
-        List<GameRequestDto> result = StreamSupport.stream(gameRequestService.findAll(pageable).spliterator(), false)
+        List<GameRequestDto> result = StreamSupport.stream(gameRequestService.findAll(gameRequestSpecification, pageable).spliterator(), false)
                 .collect(Collectors.toList());
 
         // Assert
@@ -179,17 +181,38 @@ public class GameRequestServiceImplTest {
         // Arrange
         Page<GameRequest> gameRequests = new PageImpl<>(Arrays.asList(new GameRequest(), new GameRequest()));
 
-        Mockito.when(gameRequestRepository.findAll(ArgumentMatchers.any(Pageable.class)))
+        Mockito.when(gameRequestRepository.findAll(ArgumentMatchers.any(GameRequestSpecification.class), ArgumentMatchers.any(Pageable.class)))
                 .thenReturn(gameRequests);
 
+        GameRequestSpecification gameRequestSpecification = Mockito.mock(GameRequestSpecification.class);
         Pageable pageable = Mockito.mock(Pageable.class);
 
         // Act
-        List<GameRequestDto> result = StreamSupport.stream(gameRequestService.findAll(pageable).spliterator(), false)
+        List<GameRequestDto> result = StreamSupport.stream(gameRequestService.findAll(gameRequestSpecification, pageable).spliterator(), false)
                 .collect(Collectors.toList());
 
         // Assert
         Assertions.assertFalse(result.isEmpty(), "The result shouldn't be empty if the repository returned game requests.");
+    }
+
+    @Test
+    public void count_withNullGameRequestSpecification_throwsNullPointerException() {
+        // Assert
+        Assertions.assertThrows(NullPointerException.class, () -> gameRequestService.count(null));
+    }
+
+    @Test
+    public void count_withValidGameRequestSpecification_invokesCount() {
+        // Arrange
+        Mockito.when(gameRequestRepository.count(ArgumentMatchers.any()))
+                .thenReturn(0L);
+
+        // Act
+        gameRequestService.count(Mockito.mock(GameRequestSpecification.class));
+
+        // Assert
+        Mockito.verify(gameRequestRepository, Mockito.atMostOnce())
+                .count(Mockito.any());
     }
 
     @Test

--- a/game-service/src/test/java/com/sparky/trak/game/service/impl/GameServiceImplTest.java
+++ b/game-service/src/test/java/com/sparky/trak/game/service/impl/GameServiceImplTest.java
@@ -2,6 +2,7 @@ package com.sparky.trak.game.service.impl;
 
 import com.sparky.trak.game.domain.*;
 import com.sparky.trak.game.repository.*;
+import com.sparky.trak.game.repository.specification.DeveloperSpecification;
 import com.sparky.trak.game.repository.specification.GameSpecification;
 import com.sparky.trak.game.service.PatchService;
 import com.sparky.trak.game.service.dto.GameDto;
@@ -200,6 +201,36 @@ public class GameServiceImplTest {
     }
 
     @Test
+    public void countGamesByGenreId_withNonExistentGame_throwsEntityNotFoundException() {
+        // Arrange
+        Mockito.when(genreRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(false);
+
+        Mockito.when(messageSource.getMessage(ArgumentMatchers.anyString(), ArgumentMatchers.any(Object[].class), ArgumentMatchers.any(Locale.class)))
+                .thenReturn("");
+
+        // Assert
+        Assertions.assertThrows(EntityNotFoundException.class, () -> gameService.countGamesByGenreId(0L));
+    }
+
+    @Test
+    public void countGamesByGenreId_withGenre_invokesGameGenreXrefRepository() {
+        // Arrange
+        Mockito.when(genreRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(true);
+
+        Mockito.when(gameGenreXrefRepository.count(ArgumentMatchers.any()))
+                .thenReturn(0L);
+
+        // Act
+        gameService.countGamesByGenreId(0L);
+
+        // Assert
+        Mockito.verify(gameGenreXrefRepository, Mockito.atMostOnce())
+                .count(ArgumentMatchers.any());
+    }
+
+    @Test
     public void findGamesByPlatformId_withNonExistentPlatform_throwsEntityNotFoundException() {
         // Arrange
         Mockito.when(platformRepository.existsById(ArgumentMatchers.anyLong()))
@@ -256,6 +287,36 @@ public class GameServiceImplTest {
 
         Mockito.verify(gameMapper, Mockito.atMost(2))
                 .gameToGameDto(ArgumentMatchers.any());
+    }
+
+    @Test
+    public void countGamesByPlatformId_withNonExistentPlatform_throwsEntityNotFoundException() {
+        // Arrange
+        Mockito.when(platformRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(false);
+
+        Mockito.when(messageSource.getMessage(ArgumentMatchers.anyString(), ArgumentMatchers.any(Object[].class), ArgumentMatchers.any(Locale.class)))
+                .thenReturn("");
+
+        // Assert
+        Assertions.assertThrows(EntityNotFoundException.class, () -> gameService.countGamesByPlatformId(0L));
+    }
+
+    @Test
+    public void countGamesByPlatformId_withPlatform_invokesGamePlatformXrefRepository() {
+        // Arrange
+        Mockito.when(platformRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(true);
+
+        Mockito.when(gamePlatformXrefRepository.count(ArgumentMatchers.any()))
+                .thenReturn(0L);
+
+        // Act
+        gameService.countGamesByPlatformId(0L);
+
+        // Assert
+        Mockito.verify(gamePlatformXrefRepository, Mockito.atMostOnce())
+                .count(ArgumentMatchers.any());
     }
 
     @Test
@@ -318,6 +379,36 @@ public class GameServiceImplTest {
     }
 
     @Test
+    public void countGamesByDeveloperId_withNonExistentDeveloper_throwsEntityNotFoundException() {
+        // Arrange
+        Mockito.when(developerRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(false);
+
+        Mockito.when(messageSource.getMessage(ArgumentMatchers.anyString(), ArgumentMatchers.any(Object[].class), ArgumentMatchers.any(Locale.class)))
+                .thenReturn("");
+
+        // Assert
+        Assertions.assertThrows(EntityNotFoundException.class, () -> gameService.countGamesByDeveloperId(0L));
+    }
+
+    @Test
+    public void countGamesByDeveloperId_withPlatform_invokesGameDeveloperXrefRepository() {
+        // Arrange
+        Mockito.when(developerRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(true);
+
+        Mockito.when(gameDeveloperXrefRepository.count(ArgumentMatchers.any()))
+                .thenReturn(0L);
+
+        // Act
+        gameService.countGamesByDeveloperId(0L);
+
+        // Assert
+        Mockito.verify(gameDeveloperXrefRepository, Mockito.atMostOnce())
+                .count(ArgumentMatchers.any());
+    }
+
+    @Test
     public void findGamesByPublisherId_withNonExistentPublisher_throwsEntityNotFoundException() {
         // Arrange
         Mockito.when(publisherRepository.existsById(ArgumentMatchers.anyLong()))
@@ -374,6 +465,36 @@ public class GameServiceImplTest {
 
         Mockito.verify(gameMapper, Mockito.atMost(2))
                 .gameToGameDto(ArgumentMatchers.any());
+    }
+
+    @Test
+    public void countGamesByPublisherId_withNonExistentPublisher_throwsEntityNotFoundException() {
+        // Arrange
+        Mockito.when(publisherRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(false);
+
+        Mockito.when(messageSource.getMessage(ArgumentMatchers.anyString(), ArgumentMatchers.any(Object[].class), ArgumentMatchers.any(Locale.class)))
+                .thenReturn("");
+
+        // Assert
+        Assertions.assertThrows(EntityNotFoundException.class, () -> gameService.countGamesByPublisherId(0L));
+    }
+
+    @Test
+    public void countGamesByPublisherId_withPublisher_invokesGamePublisherXrefRepository() {
+        // Arrange
+        Mockito.when(publisherRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(true);
+
+        Mockito.when(gamePublisherXrefRepository.count(ArgumentMatchers.any()))
+                .thenReturn(0L);
+
+        // Act
+        gameService.countGamesByPublisherId(0L);
+
+        // Assert
+        Mockito.verify(gamePublisherXrefRepository, Mockito.atMostOnce())
+                .count(ArgumentMatchers.any());
     }
 
     @Test
@@ -450,6 +571,26 @@ public class GameServiceImplTest {
 
         // Assert
         Assertions.assertFalse(result.isEmpty(), "The result shouldn't be empty if the repository returned games.");
+    }
+
+    @Test
+    public void count_withNullGameSpecification_throwsNullPointerException() {
+        // Assert
+        Assertions.assertThrows(NullPointerException.class, () -> gameService.count(null));
+    }
+
+    @Test
+    public void count_withValidGameSpecification_invokesCount() {
+        // Arrange
+        Mockito.when(gameRepository.count(ArgumentMatchers.any()))
+                .thenReturn(0L);
+
+        // Act
+        gameService.count(Mockito.mock(GameSpecification.class));
+
+        // Assert
+        Mockito.verify(gameRepository, Mockito.atMostOnce())
+                .count(Mockito.any());
     }
 
     @Test

--- a/game-service/src/test/java/com/sparky/trak/game/service/impl/GameUserEntryServiceImplTest.java
+++ b/game-service/src/test/java/com/sparky/trak/game/service/impl/GameUserEntryServiceImplTest.java
@@ -5,6 +5,7 @@ import com.sparky.trak.game.domain.Game;
 import com.sparky.trak.game.domain.GameUserEntry;
 import com.sparky.trak.game.domain.GameUserEntryStatus;
 import com.sparky.trak.game.repository.GameUserEntryRepository;
+import com.sparky.trak.game.repository.specification.DeveloperSpecification;
 import com.sparky.trak.game.repository.specification.GameUserEntrySpecification;
 import com.sparky.trak.game.service.AuthenticationService;
 import com.sparky.trak.game.service.PatchService;
@@ -206,6 +207,26 @@ public class GameUserEntryServiceImplTest {
 
         // Assert
         Assertions.assertFalse(result.isEmpty(), "The result shouldn't be empty if the repository returned game user entries.");
+    }
+
+    @Test
+    public void count_withNullGameUserEntrySpecification_throwsNullPointerException() {
+        // Assert
+        Assertions.assertThrows(NullPointerException.class, () -> gameUserEntryService.count(null));
+    }
+
+    @Test
+    public void count_withValidGameUserEntrySpecification_invokesCount() {
+        // Arrange
+        Mockito.when(gameUserEntryRepository.count(ArgumentMatchers.any()))
+                .thenReturn(0L);
+
+        // Act
+        gameUserEntryService.count(Mockito.mock(GameUserEntrySpecification.class));
+
+        // Assert
+        Mockito.verify(gameUserEntryRepository, Mockito.atMostOnce())
+                .count(Mockito.any());
     }
 
     @Test

--- a/game-service/src/test/java/com/sparky/trak/game/service/impl/GenreServiceImplTest.java
+++ b/game-service/src/test/java/com/sparky/trak/game/service/impl/GenreServiceImplTest.java
@@ -262,6 +262,26 @@ public class GenreServiceImplTest {
     }
 
     @Test
+    public void count_withNullGenreSpecification_throwsNullPointerException() {
+        // Assert
+        Assertions.assertThrows(NullPointerException.class, () -> genreService.count(null));
+    }
+
+    @Test
+    public void count_withValidGameUserEntrySpecification_invokesCount() {
+        // Arrange
+        Mockito.when(genreRepository.count(ArgumentMatchers.any()))
+                .thenReturn(0L);
+
+        // Act
+        genreService.count(Mockito.mock(GenreSpecification.class));
+
+        // Assert
+        Mockito.verify(genreRepository, Mockito.atMostOnce())
+                .count(Mockito.any());
+    }
+
+    @Test
     public void update_withNullGenreDto_throwsNullPointerException() {
         // Assert
         Assertions.assertThrows(NullPointerException.class, () -> genreService.update(null));

--- a/game-service/src/test/java/com/sparky/trak/game/service/impl/PlatformServiceImplTest.java
+++ b/game-service/src/test/java/com/sparky/trak/game/service/impl/PlatformServiceImplTest.java
@@ -187,6 +187,36 @@ public class PlatformServiceImplTest {
     }
 
     @Test
+    public void countPlatformsByGameId_withNonExistentGame_throwsEntityNotFoundException() {
+        // Arrange
+        Mockito.when(gameRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(false);
+
+        Mockito.when(messageSource.getMessage(ArgumentMatchers.anyString(), ArgumentMatchers.any(Object[].class), ArgumentMatchers.any(Locale.class)))
+                .thenReturn("");
+
+        // Assert
+        Assertions.assertThrows(EntityNotFoundException.class, () -> platformService.countPlatformsByGameId(0L));
+    }
+
+    @Test
+    public void countPlatformsByGameId_withGame_invokesGamePlatformXrefRepository() {
+        // Arrange
+        Mockito.when(gameRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(true);
+
+        Mockito.when(gamePlatformXrefRepository.count(ArgumentMatchers.any()))
+                .thenReturn(0L);
+
+        // Act
+        platformService.countPlatformsByGameId(0L);
+
+        // Assert
+        Mockito.verify(gamePlatformXrefRepository, Mockito.atMostOnce())
+                .count(ArgumentMatchers.any());
+    }
+
+    @Test
     public void findAll_withNoPlatformsAndNoPageable_returnsEmptyList() {
         // Arrange
         Mockito.when(platformRepository.findAll())
@@ -260,6 +290,26 @@ public class PlatformServiceImplTest {
 
         // Assert
         Assertions.assertFalse(result.isEmpty(), "The result shouldn't be empty if the repository returned platforms.");
+    }
+
+    @Test
+    public void count_withNullPlatformSpecification_throwsNullPointerException() {
+        // Assert
+        Assertions.assertThrows(NullPointerException.class, () -> platformService.count(null));
+    }
+
+    @Test
+    public void count_withPlatformSpecification_invokesCount() {
+        // Arrange
+        Mockito.when(platformRepository.count(ArgumentMatchers.any()))
+                .thenReturn(0L);
+
+        // Act
+        platformService.count(Mockito.mock(PlatformSpecification.class));
+
+        // Assert
+        Mockito.verify(platformRepository, Mockito.atMostOnce())
+                .count(Mockito.any());
     }
 
     @Test

--- a/game-service/src/test/java/com/sparky/trak/game/service/impl/PublisherServiceImplTest.java
+++ b/game-service/src/test/java/com/sparky/trak/game/service/impl/PublisherServiceImplTest.java
@@ -1,10 +1,10 @@
 package com.sparky.trak.game.service.impl;
 
-import com.sparky.trak.game.domain.Publisher;
 import com.sparky.trak.game.domain.GamePublisherXref;
-import com.sparky.trak.game.repository.PublisherRepository;
+import com.sparky.trak.game.domain.Publisher;
 import com.sparky.trak.game.repository.GamePublisherXrefRepository;
 import com.sparky.trak.game.repository.GameRepository;
+import com.sparky.trak.game.repository.PublisherRepository;
 import com.sparky.trak.game.repository.specification.PublisherSpecification;
 import com.sparky.trak.game.service.PatchService;
 import com.sparky.trak.game.service.dto.PublisherDto;
@@ -181,6 +181,36 @@ public class PublisherServiceImplTest {
     }
 
     @Test
+    public void countPublishersByGameId_withNonExistentGame_throwsEntityNotFoundException() {
+        // Arrange
+        Mockito.when(gameRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(false);
+
+        Mockito.when(messageSource.getMessage(ArgumentMatchers.anyString(), ArgumentMatchers.any(Object[].class), ArgumentMatchers.any(Locale.class)))
+                .thenReturn("");
+
+        // Assert
+        Assertions.assertThrows(EntityNotFoundException.class, () -> publisherService.countPublishersByGameId(0L));
+    }
+
+    @Test
+    public void countPublishersByGameId_withGame_invokesGamePublisherXrefRepository() {
+        // Arrange
+        Mockito.when(gameRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(true);
+
+        Mockito.when(gamePublisherXrefRepository.count(ArgumentMatchers.any()))
+                .thenReturn(0L);
+
+        // Act
+        publisherService.countPublishersByGameId(0L);
+
+        // Assert
+        Mockito.verify(gamePublisherXrefRepository, Mockito.atMostOnce())
+                .count(ArgumentMatchers.any());
+    }
+
+    @Test
     public void findAll_withNullPageable_throwsNullPointerException() {
         // Assert
         Assertions.assertThrows(NullPointerException.class, () -> publisherService.findAll(Mockito.mock(PublisherSpecification.class), null));
@@ -220,6 +250,26 @@ public class PublisherServiceImplTest {
 
         // Assert
         Assertions.assertFalse(result.isEmpty(), "The result shouldn't be empty if the repository returned companies.");
+    }
+
+    @Test
+    public void count_withNullPublisherSpecification_throwsNullPointerException() {
+        // Assert
+        Assertions.assertThrows(NullPointerException.class, () -> publisherService.count(null));
+    }
+
+    @Test
+    public void count_withPlatformSpecification_invokesCount() {
+        // Arrange
+        Mockito.when(publisherRepository.count(ArgumentMatchers.any()))
+                .thenReturn(0L);
+
+        // Act
+        publisherService.count(Mockito.mock(PublisherSpecification.class));
+
+        // Assert
+        Mockito.verify(publisherRepository, Mockito.atMostOnce())
+                .count(Mockito.any());
     }
 
     @Test


### PR DESCRIPTION
- Added new methods to the services for retrieving the counts for different paged requests to ensure the correct HATEOAS links.
- Added unit tests to the new service methods. 
- Ensured that the parameters on paged requests are passed through to the "self", "next" and "prev" links. 