### PR TITLE
API-14: Support push notifications through AWS SNS.

### DIFF
--- a/game-domain/src/main/java/com/sparky/trak/game/domain/GameRequest.java
+++ b/game-domain/src/main/java/com/sparky/trak/game/domain/GameRequest.java
@@ -3,7 +3,7 @@ package com.sparky.trak.game.domain;
 import lombok.Data;
 
 import javax.persistence.*;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Data
 @Entity
@@ -22,7 +22,7 @@ public class GameRequest {
     private boolean completed;
 
     @Column(name = "completed_date")
-    private LocalDate completedDate;
+    private LocalDateTime completedDate;
 
     @Column(name = "user_id", nullable = false, updatable = false)
     private long userId;

--- a/game-domain/src/main/resources/db/changelog/001-initial.xml
+++ b/game-domain/src/main/resources/db/changelog/001-initial.xml
@@ -177,7 +177,7 @@
             <column name="completed" type="boolean" defaultValueBoolean="false">
                 <constraints nullable="false"/>
             </column>
-            <column name="completed_date" type="date"/>
+            <column name="completed_date" type="datetime"/>
             <column name="user_id" type="bigint">
                 <constraints nullable="false" />
             </column>

--- a/game-server/src/main/java/com/sparky/trak/game/server/configuration/MessageConfig.java
+++ b/game-server/src/main/java/com/sparky/trak/game/server/configuration/MessageConfig.java
@@ -15,7 +15,7 @@ public class MessageConfig {
     @Bean
     public MessageSource messageSource() {
         ReloadableResourceBundleMessageSource reloadableResourceBundleMessageSource = new ReloadableResourceBundleMessageSource();
-        reloadableResourceBundleMessageSource.setBasenames("classpath:i18n/exception", "classpath:i18n/validation");
+        reloadableResourceBundleMessageSource.setBasenames("classpath:i18n/exception", "classpath:i18n/validation", "classpath:i18n/messages");
         reloadableResourceBundleMessageSource.setDefaultEncoding(StandardCharsets.UTF_8.displayName());
 
         return reloadableResourceBundleMessageSource;

--- a/game-server/src/main/java/com/sparky/trak/game/server/controller/GameRequestController.java
+++ b/game-server/src/main/java/com/sparky/trak/game/server/controller/GameRequestController.java
@@ -1,6 +1,7 @@
 package com.sparky.trak.game.server.controller;
 
 import com.sparky.trak.game.repository.specification.GameRequestSpecification;
+import com.sparky.trak.game.server.annotation.AllowedForAdmin;
 import com.sparky.trak.game.server.annotation.AllowedForUser;
 import com.sparky.trak.game.server.assembler.GameRequestRepresentationModelAssembler;
 import com.sparky.trak.game.server.exception.ApiError;
@@ -44,7 +45,6 @@ public class GameRequestController {
 
     private final GameRequestService gameRequestService;
     private final GameRequestRepresentationModelAssembler gameRequestRepresentationModelAssembler;
-    private final MessageSource messageSource;
 
     /**
      * End-point that will attempt to save the given {@link GameRequestDto} request body to the underlying
@@ -133,6 +133,28 @@ public class GameRequestController {
     @PutMapping
     public EntityModel<GameRequestDto> update(@Validated @RequestBody GameRequestDto gameRequestDto) {
         return gameRequestRepresentationModelAssembler.toModel(gameRequestService.update(gameRequestDto));
+    }
+
+    /**
+     * End-point that is used to complete the {@link GameRequestDto} that is associated with the given ID. When a {@link GameRequestDto}
+     * is completed, the completed value is set to true and the completion date is set to when this end-point was invoked.
+     * If the {@link GameRequestDto} is successfully completed, a push notification is sent to the user that made the
+     * initial request. If the {@link GameRequestDto} that is associated with the given ID is already completed, it is
+     * not completed again and no push notifications are sent.
+     *
+     * It should be noted that the ID should match an existing {@link GameRequestDto} instance, if not an exception will be thrown
+     * and an {@link ApiError} will be returned.
+     *
+     * As requests send push notifications, it is only available to users who have elevated admin privileges. If any issues
+     * occur during completion, an {@link ApiError} will be returned with additional exception details.
+     *
+     * @param id The ID of the {@link GameRequestDto} to complete.
+     */
+    @AllowedForAdmin
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PutMapping("/{id}/complete")
+    public void complete(@PathVariable long id) {
+        gameRequestService.complete(gameRequestService.findById(id));
     }
 
     /**

--- a/game-server/src/main/resources/i18n/messages.properties
+++ b/game-server/src/main/resources/i18n/messages.properties
@@ -1,0 +1,2 @@
+game-request.notification.complete.title=Trak
+game-request.notification.complete.content=Your request for {0} has been completed.

--- a/game-server/src/main/resources/i18n/messages_en.properties
+++ b/game-server/src/main/resources/i18n/messages_en.properties
@@ -1,0 +1,2 @@
+game-request.notification.complete.title=Trak
+game-request.notification.complete.content=Your request for {0} has been completed.

--- a/game-service/src/main/java/com/sparky/trak/game/service/GameRequestService.java
+++ b/game-service/src/main/java/com/sparky/trak/game/service/GameRequestService.java
@@ -4,6 +4,7 @@ import com.sparky.trak.game.domain.GameRequest;
 import com.sparky.trak.game.repository.specification.GameRequestSpecification;
 import com.sparky.trak.game.service.dto.GameRequestDto;
 import org.springframework.data.domain.Pageable;
+import org.springframework.lang.NonNull;
 
 import javax.json.JsonMergePatch;
 
@@ -92,6 +93,17 @@ public interface GameRequestService {
      * @throws NullPointerException Thrown if the {@link GameRequestDto} argument provided is null.
      */
     GameRequestDto update(GameRequestDto gameRequestDto);
+
+    /**
+     * Given a {@link GameRequestDto} instance, the service will attempt to complete the associated {@link GameRequestDto} and send a notification
+     * to the user that initially sent the request. Completion and notifications will only occur for a {@link GameRequestDto} that isn't already
+     * marked as completed.
+     *
+     * It is assumed that the {@link GameRequestDto} instance being passed in is valid and not equal to <code>null</code>.
+     *
+     * @param gameRequestDto The {@link GameRequestDto} to complete and send a notification against.
+     */
+    void complete(@NonNull GameRequestDto gameRequestDto);
 
     /**
      * Given a {@link JsonMergePatch} which will contain JSON information pertaining to a {@link GameRequestDto}, this method will attempt to retrieve

--- a/game-service/src/main/java/com/sparky/trak/game/service/client/NotificationClient.java
+++ b/game-service/src/main/java/com/sparky/trak/game/service/client/NotificationClient.java
@@ -1,0 +1,6 @@
+package com.sparky.trak.game.service.client;
+
+public interface NotificationClient {
+
+    void send(long userId, String title, String content);
+}

--- a/game-service/src/main/java/com/sparky/trak/game/service/client/impl/NotificationClientCircuitBreakerImpl.java
+++ b/game-service/src/main/java/com/sparky/trak/game/service/client/impl/NotificationClientCircuitBreakerImpl.java
@@ -1,0 +1,63 @@
+package com.sparky.trak.game.service.client.impl;
+
+import com.sparky.trak.game.service.AuthenticationService;
+import com.sparky.trak.game.service.client.NotificationClient;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.codec.binary.StringUtils;
+import org.bouncycastle.util.Strings;
+import org.springframework.cloud.client.circuitbreaker.CircuitBreaker;
+import org.springframework.cloud.client.circuitbreaker.CircuitBreakerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import javax.annotation.PostConstruct;
+import java.util.Arrays;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class NotificationClientCircuitBreakerImpl implements NotificationClient {
+
+    private final AuthenticationService authenticationService;
+    @SuppressWarnings("rawtypes")
+    private final CircuitBreakerFactory circuitBreakerFactory;
+    private final RestTemplate restTemplate;
+
+    @Setter
+    private CircuitBreaker notificationServerCircuitBreaker;
+
+    @PostConstruct
+    private void postConstruct() {
+        notificationServerCircuitBreaker = circuitBreakerFactory.create("notification-server-circuit-breaker");
+    }
+
+    @Override
+    public void send(long userId, String title, String content) {
+        // Ensure we specify the authentication in the headers.
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+        httpHeaders.setBearerAuth(authenticationService.getToken());
+
+        // We don't care about the return type, just the headers.
+        HttpEntity<Object> requestEntity
+                = new HttpEntity<>(null, httpHeaders);
+
+        // Encode the title and message to UTF-8 to prevent any issues with string being passed as request parameters.
+        String encodedTitle = StringUtils.newStringUtf8(title.getBytes());
+        String encodedContent = StringUtils.newStringUtf8(content.getBytes());
+
+        // Send the request using the circuit breaker pattern.
+        notificationServerCircuitBreaker.run(() ->
+                restTemplate.postForEntity("http://trak-notification-server/v1/notifications/send?user-id={userId}&title={title}&content={content}",
+                        requestEntity, Void.class, userId, encodedTitle, encodedContent), throwable -> {
+            // No point failing the whole request, just log the failure.
+            log.error("Failed to send push notification to: " + userId, throwable);
+            return null;
+        });
+    }
+}

--- a/game-service/src/main/java/com/sparky/trak/game/service/dto/GameRequestDto.java
+++ b/game-service/src/main/java/com/sparky/trak/game/service/dto/GameRequestDto.java
@@ -5,6 +5,7 @@ import org.springframework.hateoas.server.core.Relation;
 
 import javax.validation.constraints.NotEmpty;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Data
 @Relation(collectionRelation = "data", itemRelation = "game-request")
@@ -17,7 +18,7 @@ public class GameRequestDto {
 
     private boolean completed;
 
-    private LocalDate completedDate;
+    private LocalDateTime completedDate;
 
     private long userId;
 

--- a/game-service/src/test/java/com/sparky/trak/game/service/impl/GameRequestServiceImplTest.java
+++ b/game-service/src/test/java/com/sparky/trak/game/service/impl/GameRequestServiceImplTest.java
@@ -22,6 +22,7 @@ import javax.json.JsonMergePatch;
 import javax.persistence.EntityExistsException;
 import javax.persistence.EntityNotFoundException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -131,7 +132,7 @@ public class GameRequestServiceImplTest {
         gameRequest.setId(1L);
         gameRequest.setTitle("test-title");
         gameRequest.setCompleted(true);
-        gameRequest.setCompletedDate(LocalDate.now());
+        gameRequest.setCompletedDate(LocalDateTime.now());
         gameRequest.setUserId(2L);
         gameRequest.setVersion(3L);
 

--- a/game-service/src/test/java/com/sparky/trak/game/service/mapper/GameRequestMapperTest.java
+++ b/game-service/src/test/java/com/sparky/trak/game/service/mapper/GameRequestMapperTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public class GameRequestMapperTest {
 
@@ -25,7 +26,7 @@ public class GameRequestMapperTest {
         gameRequest.setId(5L);
         gameRequest.setTitle("test-game-request");
         gameRequest.setCompleted(true);
-        gameRequest.setCompletedDate(LocalDate.now());
+        gameRequest.setCompletedDate(LocalDateTime.now());
         gameRequest.setUserId(3L);
         gameRequest.setVersion(2L);
 
@@ -56,7 +57,7 @@ public class GameRequestMapperTest {
         GameRequestDto gameRequestDto = new GameRequestDto();
         gameRequestDto.setId(5L);
         gameRequestDto.setCompleted(true);
-        gameRequestDto.setCompletedDate(LocalDate.now());
+        gameRequestDto.setCompletedDate(LocalDateTime.now());
         gameRequestDto.setUserId(3L);
         gameRequestDto.setVersion(2L);
 

--- a/notification-domain/pom.xml
+++ b/notification-domain/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>trak-api</artifactId>
+        <groupId>com.sparky.trak</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.sparky.trak.notification</groupId>
+    <artifactId>notification-domain</artifactId>
+    <name>Trak API Notification domain</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/notification-domain/src/main/java/com/sparky/trak/notification/domain/MobileDeviceLink.java
+++ b/notification-domain/src/main/java/com/sparky/trak/notification/domain/MobileDeviceLink.java
@@ -1,0 +1,37 @@
+package com.sparky.trak.notification.domain;
+
+import lombok.Data;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "mobile_device_link")
+public class MobileDeviceLink {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", unique = true, nullable = false, updatable = false)
+    private long id;
+
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private long userId;
+
+    @Column(name = "device_guid", nullable = false, updatable = false)
+    private String deviceGuid;
+
+    @Column(name = "linked_date", nullable = false, updatable = false)
+    private LocalDateTime linkedDate;
+
+    @Column(name = "token", nullable = false, unique = true)
+    private String token;
+
+    @Column(name = "endpoint_arn", nullable = false, unique = true)
+    private String endpointArn;
+
+    @Version
+    @Column(name = "op_lock_version")
+    private Long version;
+}

--- a/notification-domain/src/main/resources/db/changelog/001-initial.xml
+++ b/notification-domain/src/main/resources/db/changelog/001-initial.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet author="Benjamin Carter" id="001">
+        <comment>
+            Create the initial database structure for the notification server.
+        </comment>
+
+        <!-- Create the auth_user table -->
+        <createTable tableName="mobile_device_link">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false" primaryKeyName="pk_mobile_device_link" />
+            </column>
+            <column name="user_id" type="bigint">
+                <constraints nullable="false" />
+            </column>
+            <column name="device_guid" type="varchar(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="linked_date" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="token" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="endpoint_arn" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="op_lock_version" type="bigint" defaultValueNumeric="0"/>
+        </createTable>
+
+        <!-- auth_user unique constraints -->
+        <addUniqueConstraint
+                tableName="mobile_device_link"
+                columnNames="user_id,device_guid,token"
+                constraintName="unq_mobile_device_link_user_id_device_guid_token" />
+
+        <rollback>
+            <dropTable tableName="mobile_device_link" />
+        </rollback>
+
+    </changeSet>
+</databaseChangeLog>

--- a/notification-domain/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/notification-domain/src/main/resources/db/changelog/db.changelog-master.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <include file="001-initial.xml" relativeToChangelogFile="true" />
+</databaseChangeLog>

--- a/notification-repository/pom.xml
+++ b/notification-repository/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>trak-api</artifactId>
+        <groupId>com.sparky.trak</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.sparky.trak.notification</groupId>
+    <artifactId>notification-repository</artifactId>
+    <name>Trak API Notification Repository</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <!-- Local dependencies -->
+        <dependency>
+            <groupId>com.sparky.trak.notification</groupId>
+            <artifactId>notification-domain</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/notification-repository/src/main/java/com/sparky/trak/notification/repository/MobileDeviceLinkRepository.java
+++ b/notification-repository/src/main/java/com/sparky/trak/notification/repository/MobileDeviceLinkRepository.java
@@ -1,0 +1,16 @@
+package com.sparky.trak.notification.repository;
+
+import com.sparky.trak.notification.domain.MobileDeviceLink;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Collection;
+import java.util.Optional;
+
+public interface MobileDeviceLinkRepository extends CrudRepository<MobileDeviceLink, Long> {
+
+    Collection<MobileDeviceLink> findAllByUserId(long userId);
+
+    Optional<MobileDeviceLink> findByDeviceGuid(String deviceGuid);
+
+    Optional<MobileDeviceLink> findByUserIdAndDeviceGuid(long userId, String deviceGuid);
+}

--- a/notification-server/pom.xml
+++ b/notification-server/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>trak-api</artifactId>
+        <groupId>com.sparky.trak</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.sparky.trak.notification</groupId>
+    <artifactId>notification-server</artifactId>
+    <name>Trak API Notification Server</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+        </dependency>
+        <!-- Local dependencies -->
+        <dependency>
+            <groupId>com.sparky.trak.notification</groupId>
+            <artifactId>notification-service</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/notification-server/src/main/java/com/sparky/trak/notification/server/NotificationServerApplication.java
+++ b/notification-server/src/main/java/com/sparky/trak/notification/server/NotificationServerApplication.java
@@ -1,0 +1,21 @@
+package com.sparky.trak.notification.server;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@EnableEurekaClient
+@SpringBootApplication(scanBasePackages = {
+        "com.sparky.trak.notification.service",
+        "com.sparky.trak.notification.server"
+})
+@EntityScan("com.sparky.trak.notification.domain")
+@EnableJpaRepositories("com.sparky.trak.notification.repository")
+public class NotificationServerApplication {
+
+    public static void main(String... args) {
+        SpringApplication.run(NotificationServerApplication.class, args);
+    }
+}

--- a/notification-server/src/main/java/com/sparky/trak/notification/server/adapter/SecurityConfigurerAdapter.java
+++ b/notification-server/src/main/java/com/sparky/trak/notification/server/adapter/SecurityConfigurerAdapter.java
@@ -1,0 +1,34 @@
+package com.sparky.trak.notification.server.adapter;
+
+import com.sparky.trak.notification.server.configuration.JwtConfig;
+import com.sparky.trak.notification.server.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import javax.servlet.http.HttpServletResponse;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
+
+    private final JwtConfig jwtConfig;
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+
+        http
+                .csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .exceptionHandling().authenticationEntryPoint((req, res, e) -> res.sendError(HttpServletResponse.SC_UNAUTHORIZED))
+                .and()
+                .addFilterAfter(new JwtAuthenticationFilter(jwtConfig), UsernamePasswordAuthenticationFilter.class)
+                .authorizeRequests()
+                .anyRequest()
+                .authenticated();
+    }
+}

--- a/notification-server/src/main/java/com/sparky/trak/notification/server/annotation/AllowedForAdmin.java
+++ b/notification-server/src/main/java/com/sparky/trak/notification/server/annotation/AllowedForAdmin.java
@@ -1,0 +1,13 @@
+package com.sparky.trak.notification.server.annotation;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.lang.annotation.*;
+
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@PreAuthorize("isAuthenticated() and hasRole('ADMIN')")
+public @interface AllowedForAdmin {
+}

--- a/notification-server/src/main/java/com/sparky/trak/notification/server/annotation/AllowedForModerator.java
+++ b/notification-server/src/main/java/com/sparky/trak/notification/server/annotation/AllowedForModerator.java
@@ -1,0 +1,13 @@
+package com.sparky.trak.notification.server.annotation;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.lang.annotation.*;
+
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@PreAuthorize("isAuthenticated() and hasRole('MODERATOR')")
+public @interface AllowedForModerator {
+}

--- a/notification-server/src/main/java/com/sparky/trak/notification/server/annotation/AllowedForUser.java
+++ b/notification-server/src/main/java/com/sparky/trak/notification/server/annotation/AllowedForUser.java
@@ -1,0 +1,13 @@
+package com.sparky.trak.notification.server.annotation;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.lang.annotation.*;
+
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@PreAuthorize("isAuthenticated() and hasRole('USER')")
+public @interface AllowedForUser {
+}

--- a/notification-server/src/main/java/com/sparky/trak/notification/server/configuration/EurekaClientConfiguration.java
+++ b/notification-server/src/main/java/com/sparky/trak/notification/server/configuration/EurekaClientConfiguration.java
@@ -1,0 +1,25 @@
+package com.sparky.trak.notification.server.configuration;
+
+import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.filter.ForwardedHeaderFilter;
+
+/**
+ * Enables the Eureka client functionality only if the spring profiles are either development or production.
+ * This is done so that during the integration testing phase, the game-server isn't registered as a eureka client
+ * as it can cause un-needed exceptions and registering within a discovery server isn't necessary for endpoint testing.
+ *
+ * @author Sparky Studios
+ */
+@Profile({ "development", "production" })
+@Configuration
+@EnableEurekaClient
+public class EurekaClientConfiguration {
+
+    @Bean
+    public ForwardedHeaderFilter forwardedHeaderFilter() {
+        return new ForwardedHeaderFilter();
+    }
+}

--- a/notification-server/src/main/java/com/sparky/trak/notification/server/configuration/JacksonConfig.java
+++ b/notification-server/src/main/java/com/sparky/trak/notification/server/configuration/JacksonConfig.java
@@ -1,0 +1,25 @@
+package com.sparky.trak.notification.server.configuration;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr353.JSR353Module;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                .configure(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false)
+                .registerModule(new JavaTimeModule())
+                .registerModule(new JSR353Module());
+    }
+}

--- a/notification-server/src/main/java/com/sparky/trak/notification/server/configuration/JwtConfig.java
+++ b/notification-server/src/main/java/com/sparky/trak/notification/server/configuration/JwtConfig.java
@@ -1,0 +1,16 @@
+package com.sparky.trak.notification.server.configuration;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Configuration
+public class JwtConfig {
+
+    @Value("${trak.security.jwt.auth-uri}")
+    private String authUri;
+
+    @Value("${trak.security.jwt.secret-key}")
+    private String secretKey;
+}

--- a/notification-server/src/main/java/com/sparky/trak/notification/server/configuration/MessageConfig.java
+++ b/notification-server/src/main/java/com/sparky/trak/notification/server/configuration/MessageConfig.java
@@ -1,0 +1,43 @@
+package com.sparky.trak.notification.server.configuration;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+import org.springframework.web.filter.CommonsRequestLoggingFilter;
+
+import java.nio.charset.StandardCharsets;
+
+@Configuration
+public class MessageConfig {
+
+    @Bean
+    public MessageSource messageSource() {
+        ReloadableResourceBundleMessageSource reloadableResourceBundleMessageSource = new ReloadableResourceBundleMessageSource();
+        reloadableResourceBundleMessageSource.setBasenames("classpath:i18n/exception", "classpath:i18n/validation");
+        reloadableResourceBundleMessageSource.setDefaultEncoding(StandardCharsets.UTF_8.displayName());
+
+        return reloadableResourceBundleMessageSource;
+    }
+
+    @Bean
+    public LocalValidatorFactoryBean localValidatorFactoryBean() {
+        LocalValidatorFactoryBean localValidatorFactoryBean = new LocalValidatorFactoryBean();
+        localValidatorFactoryBean.setValidationMessageSource(messageSource());
+
+        return localValidatorFactoryBean;
+    }
+
+    @Bean
+    public CommonsRequestLoggingFilter logFilter() {
+        CommonsRequestLoggingFilter filter = new CommonsRequestLoggingFilter();
+        filter.setIncludeQueryString(true);
+        filter.setIncludePayload(true);
+        filter.setIncludeQueryString(true);
+        filter.setMaxPayloadLength(10000);
+        filter.setIncludeHeaders(false);
+        filter.setAfterMessagePrefix("REQUEST DATA: ");
+        return filter;
+    }
+}

--- a/notification-server/src/main/java/com/sparky/trak/notification/server/configuration/SecurityConfig.java
+++ b/notification-server/src/main/java/com/sparky/trak/notification/server/configuration/SecurityConfig.java
@@ -1,0 +1,11 @@
+package com.sparky.trak.notification.server.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
+
+@Configuration
+@EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true, jsr250Enabled = true)
+public class SecurityConfig extends GlobalMethodSecurityConfiguration {
+
+}

--- a/notification-server/src/main/java/com/sparky/trak/notification/server/controller/NotificationController.java
+++ b/notification-server/src/main/java/com/sparky/trak/notification/server/controller/NotificationController.java
@@ -1,0 +1,94 @@
+package com.sparky.trak.notification.server.controller;
+
+import com.sparky.trak.notification.server.annotation.AllowedForAdmin;
+import com.sparky.trak.notification.server.annotation.AllowedForUser;
+import com.sparky.trak.notification.service.MobileDeviceLinkService;
+import com.sparky.trak.notification.service.NotificationService;
+import com.sparky.trak.notification.service.dto.MobileDeviceLinkRegistrationRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * The {@link NotificationController} is a simple controller class that exposes a small number of API endpoints that are used
+ * to interact with the push notification functionality. It's purpose is to be used to register and unregister linked accounts
+ * and dispatch notifications to any device.
+ *
+ * Unlike the similar email-service, all notification functionality can be accessed by any user with user credentials. No
+ * elevated privileges are needed.
+ *
+ * @since 1.0.0
+ * @author Sparky Studios
+ */
+@RequiredArgsConstructor
+@RestController
+@RequestMapping(value = "v1/notifications", produces = MediaType.APPLICATION_JSON_VALUE)
+public class NotificationController {
+
+    private final MobileDeviceLinkService mobileDeviceLinkService;
+    private final NotificationService notificationService;
+
+    /**
+     * End-point that will attempt to save a {@link com.sparky.trak.notification.domain.MobileDeviceLink} with
+     * the information provided in the {@link MobileDeviceLinkRegistrationRequestDto}. This endpoint will register
+     * the information both within the persistence layer and the third-party push notification provider. It
+     * should be noted that links can only be registered for users that have an ID matching that of the
+     * currently authenticated user.
+     *
+     * The {@link MobileDeviceLinkRegistrationRequestDto} request body must contain valid information, otherwise
+     * the end-point will return an {@link com.sparky.trak.notification.server.exception.ApiError}. an
+     * {@link com.sparky.trak.notification.server.exception.ApiError} will also be returned if any issues occur
+     * during persistence or third-party registration.
+     *
+     * @param mobileDeviceLinkRegistrationRequestDto The {@link MobileDeviceLinkRegistrationRequestDto} information to register..
+     */
+    @AllowedForUser
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PostMapping("/register")
+    public void register(@RequestBody @Validated MobileDeviceLinkRegistrationRequestDto mobileDeviceLinkRegistrationRequestDto) {
+        mobileDeviceLinkService.register(mobileDeviceLinkRegistrationRequestDto);
+    }
+
+    /**
+     * End-point that will remove any {@link com.sparky.trak.notification.domain.MobileDeviceLink}'s that are associated
+     * with the given user ID and device ID and remove the references from the underlying third-party notification service, if needed.
+     * It should be noted that links can only be unregistered for users that have an ID matching that of the currently
+     * authenticated user.
+     *
+     * If any errors are thrown during removal, an {@link com.sparky.trak.notification.server.exception.ApiError} instance
+     * will be returned with additional exception details.
+     *
+     * @param userId The unique user ID to remove the device for.
+     * @param deviceGuid The unique ID of the device to remove the notifications for.
+     */
+    @AllowedForUser
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/unregister")
+    public void unregister(@RequestParam("user-id") long userId, @RequestParam("device-guid") String deviceGuid) {
+        mobileDeviceLinkService.unregister(userId, deviceGuid);
+    }
+
+    /**
+     * End-point that is used to dispatch push notifications to all devices that are currently registered against the
+     * given user. The title and message provided <bold>must</bold> be UTF-8 encoded, otherwise it may lead to issues
+     * invoking the end-point. It should be noted that push notifications can only be registered for users that have
+     * an ID matching that of the currently authenticated user.
+     *
+     * If any errors are thrown during push notification sending, an {@link com.sparky.trak.notification.server.exception.ApiError}
+     * instance will be returned with additional exception details.
+     *
+     * @param userId The ID of the user to dispatch push notifications to.
+     * @param title The title of the push notification message.
+     * @param content The contents of the push notification message.
+     */
+    @AllowedForAdmin
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PostMapping("/send")
+    public void send(@RequestParam("user-id") long userId,
+                     @RequestParam String title,
+                     @RequestParam String content) {
+        notificationService.send(userId, title, content);
+    }
+}

--- a/notification-server/src/main/java/com/sparky/trak/notification/server/exception/ApiError.java
+++ b/notification-server/src/main/java/com/sparky/trak/notification/server/exception/ApiError.java
@@ -1,0 +1,32 @@
+package com.sparky.trak.notification.server.exception;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Data
+public class ApiError {
+
+    private HttpStatus status;
+    @Setter(AccessLevel.NONE)
+    private LocalDateTime time;
+    private String message;
+    private String debugMessage;
+
+    @Setter(AccessLevel.NONE)
+    private Collection<ApiSubError> subErrors = new ArrayList<>();
+
+    private ApiError() {
+        time = LocalDateTime.now();
+    }
+
+    public ApiError(HttpStatus status) {
+        this();
+        this.status = status;
+    }
+}

--- a/notification-server/src/main/java/com/sparky/trak/notification/server/exception/ApiSubError.java
+++ b/notification-server/src/main/java/com/sparky/trak/notification/server/exception/ApiSubError.java
@@ -1,0 +1,11 @@
+package com.sparky.trak.notification.server.exception;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = ApiValidationError.class, name = "ApiValidationError"),
+})
+public abstract class ApiSubError {
+}

--- a/notification-server/src/main/java/com/sparky/trak/notification/server/exception/ApiValidationError.java
+++ b/notification-server/src/main/java/com/sparky/trak/notification/server/exception/ApiValidationError.java
@@ -1,0 +1,18 @@
+package com.sparky.trak.notification.server.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+@AllArgsConstructor
+class ApiValidationError extends ApiSubError {
+
+    private String object;
+    private String field;
+    private Object rejectedValue;
+    private String message;
+}

--- a/notification-server/src/main/java/com/sparky/trak/notification/server/exception/GlobalExceptionHandler.java
+++ b/notification-server/src/main/java/com/sparky/trak/notification/server/exception/GlobalExceptionHandler.java
@@ -1,0 +1,104 @@
+package com.sparky.trak.notification.server.exception;
+
+import com.sparky.trak.notification.service.exception.NotificationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.lang.NonNull;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import javax.persistence.EntityExistsException;
+import javax.persistence.EntityNotFoundException;
+import javax.validation.ConstraintViolationException;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@ControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    protected ResponseEntity<Object> handleEntityNotFound(EntityNotFoundException ex) {
+        log.error("Entity not found", ex);
+
+        ApiError apiError = new ApiError(HttpStatus.NOT_FOUND);
+        apiError.setMessage(ex.getMessage());
+
+        return new ResponseEntity<>(apiError, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(EntityExistsException.class)
+    protected ResponseEntity<Object> handleEntityExists(EntityExistsException ex) {
+        log.error("Entity exists", ex);
+
+        ApiError apiError = new ApiError(HttpStatus.BAD_REQUEST);
+        apiError.setMessage(ex.getMessage());
+
+        return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(NotificationException.class)
+    protected ResponseEntity<Object> handleNotification(NotificationException ex) {
+        log.error("Notification error", ex);
+
+        ApiError apiError = new ApiError(HttpStatus.BAD_REQUEST);
+        apiError.setMessage(ex.getMessage());
+
+        return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
+    }
+
+    @Override
+    @NonNull
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(@NonNull HttpMessageNotReadableException ex, @NonNull HttpHeaders headers, @NonNull HttpStatus status, @NonNull WebRequest request) {
+        log.error("HTTP message not readable", ex);
+
+        ApiError apiError = new ApiError(HttpStatus.BAD_REQUEST);
+        apiError.setMessage(ex.getMessage());
+
+        return new ResponseEntity<>(apiError, headers, status);
+    }
+
+    @Override
+    @NonNull
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(@NonNull MethodArgumentNotValidException ex, @NonNull HttpHeaders headers, @NonNull HttpStatus status, @NonNull WebRequest request) {
+        log.error("Method argument not valid", ex);
+
+        ApiError apiError = new ApiError(HttpStatus.BAD_REQUEST);
+        apiError.setMessage(ex.getMessage());
+
+        // Stream through each sub-error and add all of them to the response.
+        apiError.getSubErrors().addAll(ex.getBindingResult().getFieldErrors()
+                .stream()
+                .map(fe -> new ApiValidationError(fe.getObjectName(), fe.getField(), fe.getRejectedValue(), fe.getDefaultMessage()))
+                .collect(Collectors.toList()));
+
+        return new ResponseEntity<>(apiError, headers, status);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    protected ResponseEntity<Object> handleConstraintViolation(ConstraintViolationException ex) {
+        log.error("Constraint violation", ex);
+
+        ApiError apiError = new ApiError(HttpStatus.BAD_REQUEST);
+        apiError.setMessage(ex.getMessage());
+
+        apiError.getSubErrors().addAll(ex.getConstraintViolations()
+                .stream()
+                .map(c -> new ApiValidationError(c.getRootBeanClass().getSimpleName(), c.getPropertyPath().toString(), c.getInvalidValue().toString(), c.getMessage()))
+                .collect(Collectors.toList()));
+
+        return ResponseEntity
+                .badRequest()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(apiError);
+    }
+}

--- a/notification-server/src/main/java/com/sparky/trak/notification/server/filter/JwtAuthenticationFilter.java
+++ b/notification-server/src/main/java/com/sparky/trak/notification/server/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,71 @@
+package com.sparky.trak.notification.server.filter;
+
+import com.sparky.trak.notification.server.configuration.JwtConfig;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtConfig jwtConfig;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest httpServletRequest, @NonNull HttpServletResponse httpServletResponse, @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        // Grab the auth header from the request.
+        String header = httpServletRequest.getHeader("Authorization");
+
+        // If no authorization has been provided, just carry on down the request filter chain.
+        if (StringUtils.isBlank(header) || !header.startsWith("Bearer ")) {
+            filterChain.doFilter(httpServletRequest, httpServletResponse);
+            return;
+        }
+
+        // If no token if provided the user won't be authenticated, but at this point they may be trying to access a publicly accessible path.
+        String token = header.replace("Bearer ", StringUtils.EMPTY);
+
+        try {
+            // Validate the token.
+            Claims claims = Jwts.parser()
+                    .setSigningKey(jwtConfig.getSecretKey().getBytes())
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            String username = claims.getSubject();
+            if (StringUtils.isNotBlank(username)) {
+                @SuppressWarnings("unchecked")
+                List<SimpleGrantedAuthority> authorities = ((List<String>) claims.get("authorities"))
+                        .stream()
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+                // Create the authenticated object, which includes the username and the authorities associated with the user.
+                UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(username, null, authorities);
+                auth.setDetails(claims.get("userId"));
+
+                // Authentication the user.
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+        } catch (Exception e) {
+            SecurityContextHolder.clearContext();
+        }
+
+        // Carry on the filter chain after authentication is done.
+        filterChain.doFilter(httpServletRequest, httpServletResponse);
+    }
+}

--- a/notification-server/src/main/resources/bootstrap.yml
+++ b/notification-server/src/main/resources/bootstrap.yml
@@ -1,0 +1,11 @@
+spring:
+  application:
+    name: trak-notification-server
+  cloud:
+    config:
+      discovery:
+        enabled: true
+        service-id: trak-config-server
+      enabled: true
+  profiles:
+    active: development

--- a/notification-server/src/main/resources/i18n/exception.properties
+++ b/notification-server/src/main/resources/i18n/exception.properties
@@ -1,0 +1,4 @@
+notifications.exception.publish-failed=Failed to send push notification to {0}.
+notifications.exception.registration-failed=Failed to retrieve AWS endpoint attributes.
+notifications.exception.delete-failed=Failed to delete AWS endpoint.
+notifications.exception.invalid-user=Cannot register or unregister from push notifications for a different user.

--- a/notification-server/src/main/resources/i18n/exception_en.properties
+++ b/notification-server/src/main/resources/i18n/exception_en.properties
@@ -1,0 +1,2 @@
+notifications.exception.publish-failed=Failed to send push notification to {0}.
+notifications.exception.registration-failed=Failed to retrieve AWS endpoint attributes.

--- a/notification-server/src/main/resources/i18n/validation.properties
+++ b/notification-server/src/main/resources/i18n/validation.properties
@@ -1,0 +1,5 @@
+mobile-device-link-registration-request.validation.device-guid.size=The device GUID should be exactly 36 characters in length.
+mobile-device-link-registration-request.validation.device-guid.not-empty=The device GUID cannot be empty or null.
+
+mobile-device-link-registration-request.validation.token.size=The token cannot exceed 255 characters in length.
+mobile-device-link-registration-request.validation.token.not-empty=The token cannot be empty or null.

--- a/notification-server/src/main/resources/i18n/validation_en.properties
+++ b/notification-server/src/main/resources/i18n/validation_en.properties
@@ -1,0 +1,5 @@
+mobile-device-link-registration-request.validation.device-guid.size=The device GUID should be exactly 36 characters in length.
+mobile-device-link-registration-request.validation.device-guid.not-empty=The device GUID cannot be empty or null.
+
+mobile-device-link-registration-request.validation.token.size=The token cannot exceed 255 characters in length.
+mobile-device-link-registration-request.validation.token.not-empty=The token cannot be empty or null.

--- a/notification-server/src/main/resources/logback-spring.xml
+++ b/notification-server/src/main/resources/logback-spring.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <property name="LOGS" value="./logs" />
+
+    <appender name="platform" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %d{yyyy-MM-dd HH:mm:ss.SSS} %-4relative [%thread] %-5level %logger{35} - %X{req.method} %X{req.requestURI} %msg %n
+            </Pattern>
+        </layout>
+    </appender>
+
+    <appender name="rolling-file" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOGS}/notification.log</file>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-4relative [%thread] %-5level %logger{35} - %X{req.method} %X{req.requestURI} %msg %n</Pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- rollover daily and when the file reaches 10 MegaBytes -->
+            <fileNamePattern>${LOGS}/archived/notification-%d{yyyy-MM-dd}.%i.log
+            </fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+        </rollingPolicy>
+    </appender>
+
+    <logger name="org.springframework.web.filter.CommonsRequestLoggingFilter">
+        <level value="DEBUG" />
+    </logger>
+
+    <root level="info">
+        <appender-ref ref="rolling-file" />
+        <appender-ref ref="platform" />
+    </root>
+
+</configuration>

--- a/notification-service/pom.xml
+++ b/notification-service/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>trak-api</artifactId>
+        <groupId>com.sparky.trak</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.sparky.trak.notification</groupId>
+    <artifactId>notification-service</artifactId>
+    <name>Trak API Notification Service</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sns</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <!-- Local dependencies -->
+        <dependency>
+            <groupId>com.sparky.trak.notification</groupId>
+            <artifactId>notification-repository</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/notification-service/src/main/java/com/sparky/trak/notification/service/AuthenticationService.java
+++ b/notification-service/src/main/java/com/sparky/trak/notification/service/AuthenticationService.java
@@ -1,0 +1,29 @@
+package com.sparky.trak.notification.service;
+
+import org.springframework.security.core.Authentication;
+
+public interface AuthenticationService {
+
+    /**
+     * Retrieves the current {@link Authentication} information from Spring Security for the user
+     * that is currently accessing the Trak API.
+     *
+     * @return The {@link Authentication} information of the current user.
+     */
+    Authentication getAuthentication();
+
+    /**
+     * Checks to see if the user that is currently interacting with the API matches the user ID provided.
+     * The primary purpose of this method is to ensure that the user is only changing information that
+     * is directly associated with their user credentials, therefore not allowing them to change information
+     * that may be directly relate to other users, which may result in unwanted results for them.
+     *
+     * The exemption to this rule is if the credentials provided have an admin role, if the user is an admin,
+     * validation based on the user ID is ignored.
+     *
+     * @param userId The user ID to validate matches the current user accessing the API.
+     *
+     * @return <code>true</code> if the current user is either an admin or matches the information provided.
+     */
+    boolean isCurrentAuthenticatedUser(long userId);
+}

--- a/notification-service/src/main/java/com/sparky/trak/notification/service/MobileDeviceLinkService.java
+++ b/notification-service/src/main/java/com/sparky/trak/notification/service/MobileDeviceLinkService.java
@@ -1,0 +1,10 @@
+package com.sparky.trak.notification.service;
+
+import com.sparky.trak.notification.service.dto.MobileDeviceLinkRegistrationRequestDto;
+
+public interface MobileDeviceLinkService {
+
+    void register(MobileDeviceLinkRegistrationRequestDto mobileDeviceLinkRegistrationRequestDto);
+
+    void unregister(long userId, String deviceGuid);
+}

--- a/notification-service/src/main/java/com/sparky/trak/notification/service/NotificationService.java
+++ b/notification-service/src/main/java/com/sparky/trak/notification/service/NotificationService.java
@@ -1,0 +1,6 @@
+package com.sparky.trak.notification.service;
+
+public interface  NotificationService {
+
+    void send(long userId, String title, String message);
+}

--- a/notification-service/src/main/java/com/sparky/trak/notification/service/configuration/AwsSimpleNotificationServiceConfig.java
+++ b/notification-service/src/main/java/com/sparky/trak/notification/service/configuration/AwsSimpleNotificationServiceConfig.java
@@ -1,0 +1,28 @@
+package com.sparky.trak.notification.service.configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.sns.AmazonSNS;
+import com.amazonaws.services.sns.AmazonSNSClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsSimpleNotificationServiceConfig {
+
+    @Value("${trak.aws.simple-notification-service.access-key}")
+    private String accessKey;
+
+    @Value("${trak.aws.simple-notification-service.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public AmazonSNS amazonSNS() {
+        return AmazonSNSClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey)))
+                .withRegion(Regions.EU_WEST_1)
+                .build();
+    }
+}

--- a/notification-service/src/main/java/com/sparky/trak/notification/service/dto/MobileDeviceLinkRegistrationRequestDto.java
+++ b/notification-service/src/main/java/com/sparky/trak/notification/service/dto/MobileDeviceLinkRegistrationRequestDto.java
@@ -1,0 +1,20 @@
+package com.sparky.trak.notification.service.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
+
+@Data
+public class MobileDeviceLinkRegistrationRequestDto {
+
+    private long userId;
+
+    @Size(min = 36, max = 36, message = "{mobile-device-link-registration-request.validation.device-guid.size}")
+    @NotEmpty(message = "{mobile-device-link-registration-request.validation.device-guid.not-empty}")
+    private String deviceGuid;
+
+    @Size(max = 255, message = "{mobile-device-link-registration-request.validation.token.size}")
+    @NotEmpty(message = "{mobile-device-link-registration-request.validation.token.not-empty}")
+    private String token;
+}

--- a/notification-service/src/main/java/com/sparky/trak/notification/service/event/MobileDeviceLinkDeletedEvent.java
+++ b/notification-service/src/main/java/com/sparky/trak/notification/service/event/MobileDeviceLinkDeletedEvent.java
@@ -1,0 +1,12 @@
+package com.sparky.trak.notification.service.event;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter(AccessLevel.NONE)
+public class MobileDeviceLinkDeletedEvent {
+
+    private final String endpointArn;
+}

--- a/notification-service/src/main/java/com/sparky/trak/notification/service/exception/InvalidUserException.java
+++ b/notification-service/src/main/java/com/sparky/trak/notification/service/exception/InvalidUserException.java
@@ -1,0 +1,20 @@
+package com.sparky.trak.notification.service.exception;
+
+public class InvalidUserException extends RuntimeException {
+
+    public InvalidUserException() {
+        super();
+    }
+
+    public InvalidUserException(String message) {
+        super(message);
+    }
+
+    public InvalidUserException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidUserException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/notification-service/src/main/java/com/sparky/trak/notification/service/exception/NotificationException.java
+++ b/notification-service/src/main/java/com/sparky/trak/notification/service/exception/NotificationException.java
@@ -1,0 +1,20 @@
+package com.sparky.trak.notification.service.exception;
+
+public class NotificationException extends RuntimeException {
+
+    public NotificationException() {
+        super();
+    }
+
+    public NotificationException(String message) {
+        super(message);
+    }
+
+    public NotificationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NotificationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/notification-service/src/main/java/com/sparky/trak/notification/service/impl/AuthenticationServiceImpl.java
+++ b/notification-service/src/main/java/com/sparky/trak/notification/service/impl/AuthenticationServiceImpl.java
@@ -1,0 +1,36 @@
+package com.sparky.trak.notification.service.impl;
+
+import com.sparky.trak.notification.service.AuthenticationService;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthenticationServiceImpl implements AuthenticationService {
+
+    @Override
+    public Authentication getAuthentication() {
+        return SecurityContextHolder.getContext().getAuthentication();
+    }
+
+    @Override
+    public boolean isCurrentAuthenticatedUser(long userId) {
+        // We can't inject this, so it has to be grabbed directly from the current context.
+        Authentication authentication = getAuthentication();
+
+        // We only check the authentication if the principal provided is the one we're expecting for authentication.
+        if (authentication instanceof UsernamePasswordAuthenticationToken) {
+            UsernamePasswordAuthenticationToken token = (UsernamePasswordAuthenticationToken)authentication;
+
+            // If the user calling the end-point has an admin role, authenticate them so that they can edit any data.
+            boolean isAdmin = token.getAuthorities()
+                    .stream()
+                    .anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN"));
+
+            return isAdmin || Long.parseLong(token.getDetails().toString()) == userId;
+        }
+
+        return false;
+    }
+}

--- a/notification-service/src/main/java/com/sparky/trak/notification/service/impl/MobileDeviceLinkServiceSnsImpl.java
+++ b/notification-service/src/main/java/com/sparky/trak/notification/service/impl/MobileDeviceLinkServiceSnsImpl.java
@@ -1,0 +1,141 @@
+package com.sparky.trak.notification.service.impl;
+
+import com.amazonaws.services.sns.AmazonSNS;
+import com.amazonaws.services.sns.model.*;
+import com.google.common.base.Strings;
+import com.sparky.trak.notification.domain.MobileDeviceLink;
+import com.sparky.trak.notification.repository.MobileDeviceLinkRepository;
+import com.sparky.trak.notification.service.AuthenticationService;
+import com.sparky.trak.notification.service.MobileDeviceLinkService;
+import com.sparky.trak.notification.service.dto.MobileDeviceLinkRegistrationRequestDto;
+import com.sparky.trak.notification.service.event.MobileDeviceLinkDeletedEvent;
+import com.sparky.trak.notification.service.exception.InvalidUserException;
+import com.sparky.trak.notification.service.exception.NotificationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MobileDeviceLinkServiceSnsImpl implements MobileDeviceLinkService {
+
+    @Value("${trak.aws.simple-notification-service.android-arn}")
+    private String androidArn;
+
+    private final AmazonSNS amazonSNS;
+    private final AuthenticationService authenticationService;
+    private final MobileDeviceLinkRepository mobileDeviceLinkRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
+    private final MessageSource messageSource;
+
+    @Override
+    public void register(MobileDeviceLinkRegistrationRequestDto mobileDeviceLinkRegistrationRequestDto) {
+        // Ensure the authenticated user is the one being registered.
+        if (!authenticationService.isCurrentAuthenticatedUser(mobileDeviceLinkRegistrationRequestDto.getUserId())) {
+            String errorMessage = messageSource
+                    .getMessage("notifications.exception.invalid-user", new Object[] {}, LocaleContextHolder.getLocale());
+
+            throw new InvalidUserException(errorMessage);
+        }
+
+        // See if we have any device links already registered for the given device.
+        Optional<MobileDeviceLink> existingDeviceLink = mobileDeviceLinkRepository.findByDeviceGuid(mobileDeviceLinkRegistrationRequestDto.getDeviceGuid());
+        String endpointArn = existingDeviceLink.isPresent() ? existingDeviceLink.get().getEndpointArn() : "";
+
+        if (Strings.isNullOrEmpty(endpointArn)) {
+            endpointArn = createEndpoint(mobileDeviceLinkRegistrationRequestDto);
+        }
+
+        try {
+            GetEndpointAttributesRequest request = new GetEndpointAttributesRequest()
+                    .withEndpointArn(endpointArn);
+
+            GetEndpointAttributesResult result = amazonSNS.getEndpointAttributes(request);
+
+            boolean updateNeeded = !result.getAttributes().get("Token").equals(mobileDeviceLinkRegistrationRequestDto.getToken()) ||
+                    !"true".equalsIgnoreCase(result.getAttributes().get("Enabled"));
+
+            if (updateNeeded) {
+                Map<String, String> attributes = new HashMap<>();
+                attributes.put("Token", mobileDeviceLinkRegistrationRequestDto.getToken());
+                attributes.put("Enabled", Boolean.TRUE.toString());
+
+                SetEndpointAttributesRequest attributesRequest = new SetEndpointAttributesRequest()
+                        .withEndpointArn(endpointArn)
+                        .withAttributes(attributes);
+
+                amazonSNS.setEndpointAttributes(attributesRequest);
+            }
+        } catch (NotFoundException nfe) {
+            if (log.isInfoEnabled()) {
+                log.info("Changes found. Creating new AWS endpoint.");
+            }
+            endpointArn = createEndpoint(mobileDeviceLinkRegistrationRequestDto);
+        } catch (@SuppressWarnings({"squid:S2221"}) Exception e) {
+            if (log.isErrorEnabled()) {
+                log.error("Failed to retrieve AWS endpoint attributes.", e);
+            }
+
+            String errorMessage =
+                    messageSource.getMessage("notifications.exception.registration-failed", new Object[]{}, LocaleContextHolder.getLocale());
+
+            throw new NotificationException(errorMessage, e);
+        }
+
+        // Once the information has been generated in AWS, we need to keep a reference so that push
+        // notifications can be dispatched to the devices.
+        MobileDeviceLink mobileDeviceLink = existingDeviceLink.orElse(new MobileDeviceLink());
+        mobileDeviceLink.setUserId(mobileDeviceLinkRegistrationRequestDto.getUserId());
+        mobileDeviceLink.setDeviceGuid(mobileDeviceLinkRegistrationRequestDto.getDeviceGuid());
+        mobileDeviceLink.setToken(mobileDeviceLinkRegistrationRequestDto.getToken());
+        mobileDeviceLink.setEndpointArn(endpointArn);
+        mobileDeviceLink.setLinkedDate(LocalDateTime.now());
+
+        mobileDeviceLinkRepository.save(mobileDeviceLink);
+    }
+
+    private String createEndpoint(MobileDeviceLinkRegistrationRequestDto mobileDeviceLinkRegistrationRequestDto) {
+        CreatePlatformEndpointRequest request = new CreatePlatformEndpointRequest()
+                .withCustomUserData(mobileDeviceLinkRegistrationRequestDto.getDeviceGuid())
+                .withPlatformApplicationArn(androidArn)
+                .withToken(mobileDeviceLinkRegistrationRequestDto.getToken());
+
+        return amazonSNS.createPlatformEndpoint(request).getEndpointArn();
+    }
+
+    @Override
+    @Transactional
+    public void unregister(long userId, String deviceGuid) {
+        // Ensure the authenticated user is the one being unregistered.
+        if (!authenticationService.isCurrentAuthenticatedUser(userId)) {
+            String errorMessage = messageSource
+                    .getMessage("notifications.exception.invalid-user", new Object[] {}, LocaleContextHolder.getLocale());
+
+            throw new InvalidUserException(errorMessage);
+        }
+
+        // Check to see if there is any mobile device link that matches the given criteria, if not throw
+        // an exception.
+        MobileDeviceLink mobileDeviceLink = mobileDeviceLinkRepository.findByUserIdAndDeviceGuid(userId, deviceGuid)
+                .orElseThrow(() -> new EntityNotFoundException(""));
+
+        // We'll want to delete the device link, regardless of whether it failed deleting in AWS.
+        mobileDeviceLinkRepository.delete(mobileDeviceLink);
+
+        // Publish the AWS endpoint deletion as an event, we don't want this called within a transaction.
+        applicationEventPublisher
+                .publishEvent(new MobileDeviceLinkDeletedEvent(mobileDeviceLink.getEndpointArn()));
+    }
+}

--- a/notification-service/src/main/java/com/sparky/trak/notification/service/impl/NotificationServiceSnsImpl.java
+++ b/notification-service/src/main/java/com/sparky/trak/notification/service/impl/NotificationServiceSnsImpl.java
@@ -1,0 +1,48 @@
+package com.sparky.trak.notification.service.impl;
+
+import com.amazonaws.services.sns.AmazonSNS;
+import com.amazonaws.services.sns.model.PublishRequest;
+import com.sparky.trak.notification.domain.MobileDeviceLink;
+import com.sparky.trak.notification.repository.MobileDeviceLinkRepository;
+import com.sparky.trak.notification.service.NotificationService;
+import com.sparky.trak.notification.service.exception.NotificationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+
+@RequiredArgsConstructor
+@Service
+public class NotificationServiceSnsImpl implements NotificationService {
+
+    private final MobileDeviceLinkRepository mobileDeviceLinkRepository;
+    private final AmazonSNS amazonSNS;
+    private final MessageSource messageSource;
+
+    @Override
+    public void send(long userId, String title, String message) {
+        // Retrieve all of the linked devices for the specified user.
+        Collection<MobileDeviceLink> mobileDeviceLinks = mobileDeviceLinkRepository
+                .findAllByUserId(userId);
+
+        for (MobileDeviceLink mobileDeviceLink : mobileDeviceLinks) {
+            // Create the push notification.
+            PublishRequest publishRequest = new PublishRequest()
+                    .withSubject(title)
+                    .withMessage(message)
+                    .withTargetArn(mobileDeviceLink.getEndpointArn());
+
+            // Publish the request through AWS.
+            try {
+                amazonSNS.publish(publishRequest);
+            } catch (Exception e) {
+                String errorMessage =
+                        messageSource.getMessage("notifications.exception.publish-failed", new Object[] {mobileDeviceLink.getToken()}, LocaleContextHolder.getLocale());
+
+                throw new NotificationException(errorMessage, e);
+            }
+        }
+    }
+}

--- a/notification-service/src/main/java/com/sparky/trak/notification/service/listener/MobileDeviceLinkListener.java
+++ b/notification-service/src/main/java/com/sparky/trak/notification/service/listener/MobileDeviceLinkListener.java
@@ -1,0 +1,38 @@
+package com.sparky.trak.notification.service.listener;
+
+import com.amazonaws.services.sns.AmazonSNS;
+import com.amazonaws.services.sns.model.DeleteEndpointRequest;
+import com.sparky.trak.notification.service.event.MobileDeviceLinkDeletedEvent;
+import com.sparky.trak.notification.service.exception.NotificationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class MobileDeviceLinkListener {
+
+    private final AmazonSNS amazonSNS;
+    private final MessageSource messageSource;
+
+    @TransactionalEventListener
+    public void onMobileDeviceLinkDeletedEvent(MobileDeviceLinkDeletedEvent event) {
+        log.info("Deleting AWS endpoint: " + event.getEndpointArn());
+
+        try {
+            DeleteEndpointRequest deleteEndpointRequest = new DeleteEndpointRequest()
+                    .withEndpointArn(event.getEndpointArn());
+
+            amazonSNS.deleteEndpoint(deleteEndpointRequest);
+        } catch (Exception e) {
+            String errorMessage =
+                    messageSource.getMessage("notifications.exception.delete-failed", new Object[]{}, LocaleContextHolder.getLocale());
+
+            throw new NotificationException(errorMessage, e);
+        }
+    }
+}

--- a/notification-service/src/test/java/com/sparky/trak/notification/service/impl/MobileDeviceLinkServiceSnsImplTest.java
+++ b/notification-service/src/test/java/com/sparky/trak/notification/service/impl/MobileDeviceLinkServiceSnsImplTest.java
@@ -1,0 +1,273 @@
+package com.sparky.trak.notification.service.impl;
+
+import com.amazonaws.services.sns.AmazonSNS;
+import com.amazonaws.services.sns.model.CreatePlatformEndpointResult;
+import com.amazonaws.services.sns.model.GetEndpointAttributesResult;
+import com.amazonaws.services.sns.model.NotFoundException;
+import com.sparky.trak.notification.domain.MobileDeviceLink;
+import com.sparky.trak.notification.repository.MobileDeviceLinkRepository;
+import com.sparky.trak.notification.service.AuthenticationService;
+import com.sparky.trak.notification.service.dto.MobileDeviceLinkRegistrationRequestDto;
+import com.sparky.trak.notification.service.event.MobileDeviceLinkDeletedEvent;
+import com.sparky.trak.notification.service.exception.InvalidUserException;
+import com.sparky.trak.notification.service.exception.NotificationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.MessageSource;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+public class MobileDeviceLinkServiceSnsImplTest {
+
+    @Mock
+    private AuthenticationService authenticationService;
+
+    @Mock
+    private MobileDeviceLinkRepository mobileDeviceLinkRepository;
+
+    @Mock
+    private AmazonSNS amazonSNS;
+
+    @Mock
+    private MessageSource messageSource;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @InjectMocks
+    private MobileDeviceLinkServiceSnsImpl mobileDeviceLinkService;
+
+    @Test
+    public void register_withIncorrectUser_throwsInvalidUserException() {
+        // Arrange
+        Mockito.when(authenticationService.isCurrentAuthenticatedUser(ArgumentMatchers.anyLong()))
+                .thenReturn(false);
+
+        // Assert
+        Assertions.assertThrows(InvalidUserException.class,
+                () -> mobileDeviceLinkService.register(new MobileDeviceLinkRegistrationRequestDto()));
+    }
+
+    @Test
+    public void register_withNonExistentMobileDeviceLink_createsEndpointAndMobileDeviceLink() {
+        // Arrange
+        MobileDeviceLinkRegistrationRequestDto mobileDeviceLinkRegistrationRequestDto = new MobileDeviceLinkRegistrationRequestDto();
+        mobileDeviceLinkRegistrationRequestDto.setToken("token");
+        mobileDeviceLinkRegistrationRequestDto.setDeviceGuid("device-guid");
+
+        Mockito.when(authenticationService.isCurrentAuthenticatedUser(ArgumentMatchers.anyLong()))
+                .thenReturn(true);
+
+        Mockito.when(mobileDeviceLinkRepository.findByDeviceGuid(ArgumentMatchers.anyString()))
+                .thenReturn(Optional.empty());
+
+        CreatePlatformEndpointResult createPlatformEndpointResult = new CreatePlatformEndpointResult()
+                .withEndpointArn("endpoint-arn");
+
+        Mockito.when(amazonSNS.createPlatformEndpoint(ArgumentMatchers.any()))
+            .thenReturn(createPlatformEndpointResult);
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("Token", mobileDeviceLinkRegistrationRequestDto.getToken());
+        attributes.put("Enabled", Boolean.TRUE.toString());
+
+        GetEndpointAttributesResult getEndpointAttributesResult = new GetEndpointAttributesResult()
+                .withAttributes(attributes);
+
+        Mockito.when(amazonSNS.getEndpointAttributes(ArgumentMatchers.any()))
+                .thenReturn(getEndpointAttributesResult);
+
+        Mockito.when(mobileDeviceLinkRepository.save(ArgumentMatchers.any()))
+                .thenReturn(null);
+
+        // Act
+        mobileDeviceLinkService.register(mobileDeviceLinkRegistrationRequestDto);
+
+        // Assert
+        Mockito.verify(amazonSNS, Mockito.atMostOnce())
+                .createPlatformEndpoint(ArgumentMatchers.any());
+
+        Mockito.verify(amazonSNS, Mockito.never())
+                .setEndpointAttributes(ArgumentMatchers.any());
+
+        Mockito.verify(mobileDeviceLinkRepository, Mockito.atMostOnce())
+                .save(ArgumentMatchers.any());
+    }
+
+    @Test
+    public void register_withEndpointAttributesThatNeedUpdating_invokesSetEndpointAttributes() {
+        // Arrange
+        MobileDeviceLinkRegistrationRequestDto mobileDeviceLinkRegistrationRequestDto = new MobileDeviceLinkRegistrationRequestDto();
+        mobileDeviceLinkRegistrationRequestDto.setToken("token");
+        mobileDeviceLinkRegistrationRequestDto.setDeviceGuid("device-guid");
+
+        Mockito.when(authenticationService.isCurrentAuthenticatedUser(ArgumentMatchers.anyLong()))
+                .thenReturn(true);
+
+        Mockito.when(mobileDeviceLinkRepository.findByDeviceGuid(ArgumentMatchers.anyString()))
+                .thenReturn(Optional.empty());
+
+        CreatePlatformEndpointResult createPlatformEndpointResult = new CreatePlatformEndpointResult()
+                .withEndpointArn("endpoint-arn");
+
+        Mockito.when(amazonSNS.createPlatformEndpoint(ArgumentMatchers.any()))
+                .thenReturn(createPlatformEndpointResult);
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("Token", "token-1");
+        attributes.put("Enabled", Boolean.TRUE.toString());
+
+        GetEndpointAttributesResult getEndpointAttributesResult = new GetEndpointAttributesResult()
+                .withAttributes(attributes);
+
+        Mockito.when(amazonSNS.getEndpointAttributes(ArgumentMatchers.any()))
+                .thenReturn(getEndpointAttributesResult);
+
+        Mockito.when(mobileDeviceLinkRepository.save(ArgumentMatchers.any()))
+                .thenReturn(null);
+
+        // Act
+        mobileDeviceLinkService.register(mobileDeviceLinkRegistrationRequestDto);
+
+        // Assert
+        Mockito.verify(amazonSNS, Mockito.atMostOnce())
+                .createPlatformEndpoint(ArgumentMatchers.any());
+
+        Mockito.verify(amazonSNS, Mockito.atMostOnce())
+                .setEndpointAttributes(ArgumentMatchers.any());
+
+        Mockito.verify(mobileDeviceLinkRepository, Mockito.atMostOnce())
+                .save(ArgumentMatchers.any());
+    }
+
+    @Test
+    public void register_withNotFoundException_recreatedEndpointArn() {
+        // Arrange
+        MobileDeviceLinkRegistrationRequestDto mobileDeviceLinkRegistrationRequestDto = new MobileDeviceLinkRegistrationRequestDto();
+        mobileDeviceLinkRegistrationRequestDto.setToken("token");
+        mobileDeviceLinkRegistrationRequestDto.setDeviceGuid("device-guid");
+
+        Mockito.when(authenticationService.isCurrentAuthenticatedUser(ArgumentMatchers.anyLong()))
+                .thenReturn(true);
+
+        Mockito.when(mobileDeviceLinkRepository.findByDeviceGuid(ArgumentMatchers.anyString()))
+                .thenReturn(Optional.empty());
+
+        CreatePlatformEndpointResult createPlatformEndpointResult = new CreatePlatformEndpointResult()
+                .withEndpointArn("endpoint-arn");
+
+        Mockito.when(amazonSNS.createPlatformEndpoint(ArgumentMatchers.any()))
+                .thenReturn(createPlatformEndpointResult);
+
+        Mockito.when(amazonSNS.getEndpointAttributes(ArgumentMatchers.any()))
+                .thenThrow(new NotFoundException(""));
+
+        Mockito.when(mobileDeviceLinkRepository.save(ArgumentMatchers.any()))
+                .thenReturn(null);
+
+        // Act
+        mobileDeviceLinkService.register(mobileDeviceLinkRegistrationRequestDto);
+
+        // Assert
+        Mockito.verify(amazonSNS, Mockito.atMost(2))
+                .createPlatformEndpoint(ArgumentMatchers.any());
+
+        Mockito.verify(amazonSNS, Mockito.atMostOnce())
+                .setEndpointAttributes(ArgumentMatchers.any());
+
+        Mockito.verify(mobileDeviceLinkRepository, Mockito.atMostOnce())
+                .save(ArgumentMatchers.any());
+    }
+
+    @Test
+    public void register_withGenericException_throwsNotificationException() {
+        // Arrange
+        MobileDeviceLinkRegistrationRequestDto mobileDeviceLinkRegistrationRequestDto = new MobileDeviceLinkRegistrationRequestDto();
+        mobileDeviceLinkRegistrationRequestDto.setToken("token");
+        mobileDeviceLinkRegistrationRequestDto.setDeviceGuid("device-guid");
+
+        Mockito.when(authenticationService.isCurrentAuthenticatedUser(ArgumentMatchers.anyLong()))
+                .thenReturn(true);
+
+        Mockito.when(mobileDeviceLinkRepository.findByDeviceGuid(ArgumentMatchers.anyString()))
+                .thenReturn(Optional.empty());
+
+        CreatePlatformEndpointResult createPlatformEndpointResult = new CreatePlatformEndpointResult()
+                .withEndpointArn("endpoint-arn");
+
+        Mockito.when(amazonSNS.createPlatformEndpoint(ArgumentMatchers.any()))
+                .thenReturn(createPlatformEndpointResult);
+
+        Mockito.when(amazonSNS.getEndpointAttributes(ArgumentMatchers.any()))
+                .thenThrow(new RuntimeException());
+
+        Mockito.when(messageSource.getMessage(ArgumentMatchers.anyString(), ArgumentMatchers.any(Object[].class), ArgumentMatchers.any(Locale.class)))
+                .thenReturn("");
+
+        // Assert
+        Assertions.assertThrows(NotificationException.class,
+                () -> mobileDeviceLinkService.register(mobileDeviceLinkRegistrationRequestDto));
+    }
+
+    @Test
+    public void unregister_withIncorrectUser_throwsInvalidUserException() {
+        // Arrange
+        Mockito.when(authenticationService.isCurrentAuthenticatedUser(ArgumentMatchers.anyLong()))
+                .thenReturn(false);
+
+        // Assert
+        Assertions.assertThrows(InvalidUserException.class,
+                () -> mobileDeviceLinkService.unregister(0L, ""));
+    }
+
+    @Test
+    public void unregister_withNoMobileDeviceLink_throwsEntityNotFoundException() {
+        // Arrange
+        Mockito.when(authenticationService.isCurrentAuthenticatedUser(ArgumentMatchers.anyLong()))
+                .thenReturn(true);
+
+        Mockito.when(mobileDeviceLinkRepository.findByUserIdAndDeviceGuid(ArgumentMatchers.anyLong(), ArgumentMatchers.anyString()))
+                .thenReturn(Optional.empty());
+
+        // Assert
+        Assertions.assertThrows(EntityNotFoundException.class, () -> mobileDeviceLinkService.unregister(0L , ""));
+    }
+
+    @Test
+    public void unregister_withMobileDeviceLink_deletesAndInvokesEvent() {
+        // Arrange
+        Mockito.when(authenticationService.isCurrentAuthenticatedUser(ArgumentMatchers.anyLong()))
+                .thenReturn(true);
+
+        Mockito.when(mobileDeviceLinkRepository.findByUserIdAndDeviceGuid(ArgumentMatchers.anyLong(), ArgumentMatchers.anyString()))
+                .thenReturn(Optional.of(new MobileDeviceLink()));
+
+        Mockito.doNothing().when(mobileDeviceLinkRepository)
+                .delete(ArgumentMatchers.any());
+
+        Mockito.doNothing().when(applicationEventPublisher)
+                .publishEvent(ArgumentMatchers.any(MobileDeviceLinkDeletedEvent.class));
+
+        // Act
+        mobileDeviceLinkService.unregister(0L, "");
+
+        // Assert
+        Mockito.verify(mobileDeviceLinkRepository, Mockito.atMostOnce())
+                .delete(ArgumentMatchers.any());
+
+        Mockito.verify(applicationEventPublisher, Mockito.atMostOnce())
+                .publishEvent(ArgumentMatchers.any(MobileDeviceLinkDeletedEvent.class));
+    }
+}

--- a/notification-service/src/test/java/com/sparky/trak/notification/service/impl/NotificationServiceSnsImplTest.java
+++ b/notification-service/src/test/java/com/sparky/trak/notification/service/impl/NotificationServiceSnsImplTest.java
@@ -1,0 +1,92 @@
+package com.sparky.trak.notification.service.impl;
+
+import com.amazonaws.services.sns.AmazonSNS;
+import com.sparky.trak.notification.domain.MobileDeviceLink;
+import com.sparky.trak.notification.repository.MobileDeviceLinkRepository;
+import com.sparky.trak.notification.service.exception.NotificationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.MessageSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Locale;
+
+@ExtendWith(MockitoExtension.class)
+public class NotificationServiceSnsImplTest {
+
+    @Mock
+    private MobileDeviceLinkRepository mobileDeviceLinkRepository;
+
+    @Mock
+    private AmazonSNS amazonSNS;
+
+    @Mock
+    private MessageSource messageSource;
+
+    @InjectMocks
+    private NotificationServiceSnsImpl notificationService;
+
+    @Test
+    public void send_withEmptyMobileDeviceLinks_doesntPublishNotifications() {
+        // Arrange
+        Mockito.when(mobileDeviceLinkRepository.findAllByUserId(ArgumentMatchers.anyLong()))
+                .thenReturn(Collections.emptyList());
+
+        // Act
+        notificationService.send(0L, "test-title", "test-message");
+
+        // Assert
+        Mockito.verify(amazonSNS, Mockito.never())
+            .publish(ArgumentMatchers.any());
+    }
+
+    @Test
+    public void send_withErroneousPublishRequest_throwsNotificationException() {
+        // Arrange
+        MobileDeviceLink mobileDeviceLink = new MobileDeviceLink();
+        mobileDeviceLink.setEndpointArn("endpoint-arn");
+
+        Mockito.when(mobileDeviceLinkRepository.findAllByUserId(ArgumentMatchers.anyLong()))
+                .thenReturn(Collections.singletonList(mobileDeviceLink));
+
+        Mockito.when(amazonSNS.publish(ArgumentMatchers.any()))
+                .thenThrow(new RuntimeException());
+
+        Mockito.when(messageSource.getMessage(ArgumentMatchers.anyString(), ArgumentMatchers.any(Object[].class), ArgumentMatchers.any(Locale.class)))
+                .thenReturn("");
+
+        // Assert
+        Assertions.assertThrows(NotificationException.class,
+                () -> notificationService.send(0L, "test-title", "test-message"));
+    }
+
+    @Test
+    public void send_withValidMobileDeviceLinks_invokesPublish() {
+        // Arrange
+        MobileDeviceLink mobileDeviceLink1 = new MobileDeviceLink();
+        mobileDeviceLink1.setEndpointArn("endpoint-arn-1");
+
+        MobileDeviceLink mobileDeviceLink2 = new MobileDeviceLink();
+        mobileDeviceLink2.setEndpointArn("endpoint-arn-2");
+
+        Mockito.when(mobileDeviceLinkRepository.findAllByUserId(ArgumentMatchers.anyLong()))
+                .thenReturn(Arrays.asList(mobileDeviceLink1, mobileDeviceLink2));
+
+        Mockito.when(amazonSNS.publish(ArgumentMatchers.any()))
+            .thenReturn(null);
+
+        // Act
+        notificationService.send(0L, "test-title", "test-message");
+
+        // Assert
+        Mockito.verify(amazonSNS, Mockito.atMost(2))
+                .publish(ArgumentMatchers.any());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,10 @@
         <module>email-server</module>
         <module>image-service</module>
         <module>image-server</module>
+        <module>notification-domain</module>
+        <module>notification-repository</module>
+        <module>notification-service</module>
+        <module>notification-server</module>
     </modules>
 
     <repositories>


### PR DESCRIPTION
- Created a number of new modules, used for sending notifications and retaining mobile device links between devices registered through Trak and AWS.
- Implemented AWS SNS services to send push notifications through AWS.
- Added unit tests for new functionality.
- Added new request to complete game requests made by users, which will complete a game request and send a push notification to the user who requested it. 
- Added support within AWS for sending  push notifications to Android devices (through Firebase).  