### PR TITLE
Small API changes.

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -26,8 +26,10 @@ phases:
         then
         	pull_request_number="${branch_name:3}"
         	mvn verify sonar:sonar -Pcoverage -Dsonar.pullrequest.provider=Github -Dsonar.pullrequest.github.repository=sparky-studios/trak-api -Dsonar.pullrequest.key=$pull_request_number -Dsonar.pullrequest.branch=$CODEBUILD_WEBHOOK_HEAD_REF
-        else
-        	mvn verify sonar:sonar -Pcoverage
+        fi
+        if [[ "$CODEBUILD_WEBHOOK_EVENT" == "PULL_REQUEST_MERGED" ]] ;
+        then
+          mvn verify sonar:sonar -Pcoverage -Dsonar.branch.name=develop
         fi
       - echo [INFO] Packaging Trak API `date`
       - mvn package -DskipTests

--- a/game-server/src/main/java/com/traklibrary/game/server/configuration/TrakHalJsonMediaTypeConfiguration.java
+++ b/game-server/src/main/java/com/traklibrary/game/server/configuration/TrakHalJsonMediaTypeConfiguration.java
@@ -6,18 +6,39 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.datatype.jsr353.JSR353Module;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.hateoas.client.LinkDiscoverer;
 import org.springframework.hateoas.config.HypermediaMappingInformation;
 import org.springframework.hateoas.mediatype.MessageResolver;
 import org.springframework.hateoas.mediatype.hal.CurieProvider;
+import org.springframework.hateoas.mediatype.hal.HalConfiguration;
+import org.springframework.hateoas.mediatype.hal.HalLinkDiscoverer;
 import org.springframework.hateoas.mediatype.hal.Jackson2HalModule;
+import org.springframework.hateoas.server.LinkRelationProvider;
 import org.springframework.hateoas.server.core.EvoInflectorLinkRelationProvider;
 import org.springframework.http.MediaType;
 
 import java.util.List;
 
+@RequiredArgsConstructor
 @Configuration
 public class TrakHalJsonMediaTypeConfiguration implements HypermediaMappingInformation {
+
+    private final LinkRelationProvider relProvider;
+    private final ObjectProvider<CurieProvider> curieProvider;
+    private final ObjectProvider<HalConfiguration> halConfiguration;
+    @Qualifier("messageResolver")
+    private final MessageResolver resolver;
+
+    @Bean
+    public LinkDiscoverer halLinkDiscoverer() {
+        return new HalLinkDiscoverer();
+    }
 
     @Override
     public Module getJacksonModule() {
@@ -30,8 +51,9 @@ public class TrakHalJsonMediaTypeConfiguration implements HypermediaMappingInfor
         mapper.registerModule(getJacksonModule());
         mapper.registerModule(new JSR353Module());
 
-        mapper.setHandlerInstantiator(new Jackson2HalModule.HalHandlerInstantiator(new EvoInflectorLinkRelationProvider(),
-                CurieProvider.NONE, MessageResolver.DEFAULTS_ONLY));
+        mapper.setHandlerInstantiator(new Jackson2HalModule.HalHandlerInstantiator(relProvider,
+                curieProvider.getIfAvailable(() -> CurieProvider.NONE), resolver, true,
+                halConfiguration.getIfAvailable(HalConfiguration::new)));
 
         mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);

--- a/game-server/src/main/java/com/traklibrary/game/server/configuration/TrakHalJsonMediaTypeConfiguration.java
+++ b/game-server/src/main/java/com/traklibrary/game/server/configuration/TrakHalJsonMediaTypeConfiguration.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.datatype.jsr353.JSR353Module;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.hateoas.client.LinkDiscoverer;
@@ -20,7 +19,6 @@ import org.springframework.hateoas.mediatype.hal.HalConfiguration;
 import org.springframework.hateoas.mediatype.hal.HalLinkDiscoverer;
 import org.springframework.hateoas.mediatype.hal.Jackson2HalModule;
 import org.springframework.hateoas.server.LinkRelationProvider;
-import org.springframework.hateoas.server.core.EvoInflectorLinkRelationProvider;
 import org.springframework.http.MediaType;
 
 import java.util.List;

--- a/game-server/src/test/java/com/traklibrary/game/server/controller/DeveloperControllerTest.java
+++ b/game-server/src/test/java/com/traklibrary/game/server/controller/DeveloperControllerTest.java
@@ -202,8 +202,8 @@ class DeveloperControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGameDto("._embedded.gameDtoes[0]", resultActions, gameDto1);
-        ResponseVerifier.verifyGameDto("._embedded.gameDtoes[1]", resultActions, gameDto2);
+        ResponseVerifier.verifyGameDto("._embedded.data[0]", resultActions, gameDto1);
+        ResponseVerifier.verifyGameDto("._embedded.data[1]", resultActions, gameDto2);
     }
 
     @Test
@@ -247,8 +247,8 @@ class DeveloperControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGameDto("._embedded.gameDtoes[0]", resultActions, gameDto1);
-        ResponseVerifier.verifyGameDto("._embedded.gameDtoes[1]", resultActions, gameDto2);
+        ResponseVerifier.verifyGameDto("._embedded.data[0]", resultActions, gameDto1);
+        ResponseVerifier.verifyGameDto("._embedded.data[1]", resultActions, gameDto2);
     }
 
     @Test
@@ -317,8 +317,8 @@ class DeveloperControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyDeveloperDto("._embedded.developerDtoes[0]", resultActions, developerDto1);
-        ResponseVerifier.verifyDeveloperDto("._embedded.developerDtoes[1]", resultActions, developerDto2);
+        ResponseVerifier.verifyDeveloperDto("._embedded.data[0]", resultActions, developerDto1);
+        ResponseVerifier.verifyDeveloperDto("._embedded.data[1]", resultActions, developerDto2);
     }
 
     @Test
@@ -360,8 +360,8 @@ class DeveloperControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyDeveloperDto("._embedded.developerDtoes[0]", resultActions, developerDto1);
-        ResponseVerifier.verifyDeveloperDto("._embedded.developerDtoes[1]", resultActions, developerDto2);
+        ResponseVerifier.verifyDeveloperDto("._embedded.data[0]", resultActions, developerDto1);
+        ResponseVerifier.verifyDeveloperDto("._embedded.data[1]", resultActions, developerDto2);
     }
 
     @Test

--- a/game-server/src/test/java/com/traklibrary/game/server/controller/GameControllerTest.java
+++ b/game-server/src/test/java/com/traklibrary/game/server/controller/GameControllerTest.java
@@ -281,8 +281,8 @@ class GameControllerTest {
         resultActions
                 .andExpect(MockMvcResultMatchers.status().isOk());
 
-        ResponseVerifier.verifyGenreDto("._embedded.genreDtoes[0]", resultActions, genreDto1);
-        ResponseVerifier.verifyGenreDto("._embedded.genreDtoes[1]", resultActions, genreDto2);
+        ResponseVerifier.verifyGenreDto("._embedded.data[0]", resultActions, genreDto1);
+        ResponseVerifier.verifyGenreDto("._embedded.data[1]", resultActions, genreDto2);
     }
 
     @Test
@@ -329,8 +329,8 @@ class GameControllerTest {
         resultActions
                 .andExpect(MockMvcResultMatchers.status().isOk());
 
-        ResponseVerifier.verifyPlatformDto("._embedded.platformDtoes[0]", resultActions, platformDto1);
-        ResponseVerifier.verifyPlatformDto("._embedded.platformDtoes[1]", resultActions, platformDto2);
+        ResponseVerifier.verifyPlatformDto("._embedded.data[0]", resultActions, platformDto1);
+        ResponseVerifier.verifyPlatformDto("._embedded.data[1]", resultActions, platformDto2);
     }
 
     @Test
@@ -377,8 +377,8 @@ class GameControllerTest {
         resultActions
                 .andExpect(MockMvcResultMatchers.status().isOk());
 
-        ResponseVerifier.verifyDeveloperDto("._embedded.developerDtoes[0]", resultActions, developerDto1);
-        ResponseVerifier.verifyDeveloperDto("._embedded.developerDtoes[1]", resultActions, developerDto2);
+        ResponseVerifier.verifyDeveloperDto("._embedded.data[0]", resultActions, developerDto1);
+        ResponseVerifier.verifyDeveloperDto("._embedded.data[1]", resultActions, developerDto2);
     }
 
     @Test
@@ -425,8 +425,8 @@ class GameControllerTest {
         resultActions
                 .andExpect(MockMvcResultMatchers.status().isOk());
 
-        ResponseVerifier.verifyPublisherDto("._embedded.publisherDtoes[0]", resultActions, publisherDto1);
-        ResponseVerifier.verifyPublisherDto("._embedded.publisherDtoes[1]", resultActions, publisherDto2);
+        ResponseVerifier.verifyPublisherDto("._embedded.data[0]", resultActions, publisherDto1);
+        ResponseVerifier.verifyPublisherDto("._embedded.data[1]", resultActions, publisherDto2);
     }
 
     @Test
@@ -505,8 +505,8 @@ class GameControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGameUserEntryDto("._embedded.gameUserEntryDtoes[0]", resultActions, gameUserEntryDto1);
-        ResponseVerifier.verifyGameUserEntryDto("._embedded.gameUserEntryDtoes[1]", resultActions, gameUserEntryDto2);
+        ResponseVerifier.verifyGameUserEntryDto("._embedded.data[0]", resultActions, gameUserEntryDto1);
+        ResponseVerifier.verifyGameUserEntryDto("._embedded.data[1]", resultActions, gameUserEntryDto2);
     }
 
     @Test
@@ -558,8 +558,8 @@ class GameControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGameUserEntryDto("._embedded.gameUserEntryDtoes[0]", resultActions, gameUserEntryDto1);
-        ResponseVerifier.verifyGameUserEntryDto("._embedded.gameUserEntryDtoes[1]", resultActions, gameUserEntryDto2);
+        ResponseVerifier.verifyGameUserEntryDto("._embedded.data[0]", resultActions, gameUserEntryDto1);
+        ResponseVerifier.verifyGameUserEntryDto("._embedded.data[1]", resultActions, gameUserEntryDto2);
     }
 
     @Test
@@ -649,8 +649,8 @@ class GameControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGameDto("._embedded.gameDtoes[0]", resultActions, gameDto1);
-        ResponseVerifier.verifyGameDto("._embedded.gameDtoes[1]", resultActions, gameDto2);
+        ResponseVerifier.verifyGameDto("._embedded.data[0]", resultActions, gameDto1);
+        ResponseVerifier.verifyGameDto("._embedded.data[1]", resultActions, gameDto2);
     }
 
     @Test
@@ -694,8 +694,8 @@ class GameControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGameDto("._embedded.gameDtoes[0]", resultActions, gameDto1);
-        ResponseVerifier.verifyGameDto("._embedded.gameDtoes[1]", resultActions, gameDto2);
+        ResponseVerifier.verifyGameDto("._embedded.data[0]", resultActions, gameDto1);
+        ResponseVerifier.verifyGameDto("._embedded.data[1]", resultActions, gameDto2);
     }
 
     @Test
@@ -766,8 +766,8 @@ class GameControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGameInfoDto("._embedded.gameInfoDtoes[0]", resultActions, gameInfoDto1);
-        ResponseVerifier.verifyGameInfoDto("._embedded.gameInfoDtoes[1]", resultActions, gameInfoDto2);
+        ResponseVerifier.verifyGameInfoDto("._embedded.data[0]", resultActions, gameInfoDto1);
+        ResponseVerifier.verifyGameInfoDto("._embedded.data[1]", resultActions, gameInfoDto2);
     }
 
     @Test
@@ -811,8 +811,8 @@ class GameControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGameInfoDto("._embedded.gameInfoDtoes[0]", resultActions, gameInfoDto1);
-        ResponseVerifier.verifyGameInfoDto("._embedded.gameInfoDtoes[1]", resultActions, gameInfoDto2);
+        ResponseVerifier.verifyGameInfoDto("._embedded.data[0]", resultActions, gameInfoDto1);
+        ResponseVerifier.verifyGameInfoDto("._embedded.data[1]", resultActions, gameInfoDto2);
     }
 
     @Test

--- a/game-server/src/test/java/com/traklibrary/game/server/controller/GameRequestControllerTest.java
+++ b/game-server/src/test/java/com/traklibrary/game/server/controller/GameRequestControllerTest.java
@@ -196,8 +196,8 @@ class GameRequestControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGameRequestDto("._embedded.gameRequestDtoes[0]", resultActions, gameRequestDto1);
-        ResponseVerifier.verifyGameRequestDto("._embedded.gameRequestDtoes[1]", resultActions, gameRequestDto2);
+        ResponseVerifier.verifyGameRequestDto("._embedded.data[0]", resultActions, gameRequestDto1);
+        ResponseVerifier.verifyGameRequestDto("._embedded.data[1]", resultActions, gameRequestDto2);
     }
 
     @Test
@@ -243,8 +243,8 @@ class GameRequestControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGameRequestDto("._embedded.gameRequestDtoes[0]", resultActions, gameRequestDto1);
-        ResponseVerifier.verifyGameRequestDto("._embedded.gameRequestDtoes[1]", resultActions, gameRequestDto2);
+        ResponseVerifier.verifyGameRequestDto("._embedded.data[0]", resultActions, gameRequestDto1);
+        ResponseVerifier.verifyGameRequestDto("._embedded.data[1]", resultActions, gameRequestDto2);
     }
 
     @Test

--- a/game-server/src/test/java/com/traklibrary/game/server/controller/GameUserEntryControllerTest.java
+++ b/game-server/src/test/java/com/traklibrary/game/server/controller/GameUserEntryControllerTest.java
@@ -209,8 +209,8 @@ public class GameUserEntryControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGameUserEntryDto("._embedded.gameUserEntryDtoes[0]", resultActions, gameUserEntryDto1);
-        ResponseVerifier.verifyGameUserEntryDto("._embedded.gameUserEntryDtoes[1]", resultActions, gameUserEntryDto2);
+        ResponseVerifier.verifyGameUserEntryDto("._embedded.data[0]", resultActions, gameUserEntryDto1);
+        ResponseVerifier.verifyGameUserEntryDto("._embedded.data[1]", resultActions, gameUserEntryDto2);
     }
 
     @Test
@@ -262,8 +262,8 @@ public class GameUserEntryControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGameUserEntryDto("._embedded.gameUserEntryDtoes[0]", resultActions, gameUserEntryDto1);
-        ResponseVerifier.verifyGameUserEntryDto("._embedded.gameUserEntryDtoes[1]", resultActions, gameUserEntryDto2);
+        ResponseVerifier.verifyGameUserEntryDto("._embedded.data[0]", resultActions, gameUserEntryDto1);
+        ResponseVerifier.verifyGameUserEntryDto("._embedded.data[1]", resultActions, gameUserEntryDto2);
     }
 
     @Test

--- a/game-server/src/test/java/com/traklibrary/game/server/controller/GenreControllerTest.java
+++ b/game-server/src/test/java/com/traklibrary/game/server/controller/GenreControllerTest.java
@@ -212,8 +212,8 @@ public class GenreControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGameDto("._embedded.gameDtoes[0]", resultActions, gameDto1);
-        ResponseVerifier.verifyGameDto("._embedded.gameDtoes[1]", resultActions, gameDto2);
+        ResponseVerifier.verifyGameDto("._embedded.data[0]", resultActions, gameDto1);
+        ResponseVerifier.verifyGameDto("._embedded.data[1]", resultActions, gameDto2);
     }
 
     @Test
@@ -257,8 +257,8 @@ public class GenreControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGameDto("._embedded.gameDtoes[0]", resultActions, gameDto1);
-        ResponseVerifier.verifyGameDto("._embedded.gameDtoes[1]", resultActions, gameDto2);
+        ResponseVerifier.verifyGameDto("._embedded.data[0]", resultActions, gameDto1);
+        ResponseVerifier.verifyGameDto("._embedded.data[1]", resultActions, gameDto2);
     }
 
     @Test
@@ -329,8 +329,8 @@ public class GenreControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGameInfoDto("._embedded.gameInfoDtoes[0]", resultActions, gameInfoDto1);
-        ResponseVerifier.verifyGameInfoDto("._embedded.gameInfoDtoes[1]", resultActions, gameInfoDto2);
+        ResponseVerifier.verifyGameInfoDto("._embedded.data[0]", resultActions, gameInfoDto1);
+        ResponseVerifier.verifyGameInfoDto("._embedded.data[1]", resultActions, gameInfoDto2);
     }
 
     @Test
@@ -374,8 +374,8 @@ public class GenreControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGameInfoDto("._embedded.gameInfoDtoes[0]", resultActions, gameInfoDto1);
-        ResponseVerifier.verifyGameInfoDto("._embedded.gameInfoDtoes[1]", resultActions, gameInfoDto2);
+        ResponseVerifier.verifyGameInfoDto("._embedded.data[0]", resultActions, gameInfoDto1);
+        ResponseVerifier.verifyGameInfoDto("._embedded.data[1]", resultActions, gameInfoDto2);
     }
 
     @Test
@@ -442,8 +442,8 @@ public class GenreControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGenreDto("._embedded.genreDtoes[0]", resultActions, genreDto1);
-        ResponseVerifier.verifyGenreDto("._embedded.genreDtoes[1]", resultActions, genreDto2);
+        ResponseVerifier.verifyGenreDto("._embedded.data[0]", resultActions, genreDto1);
+        ResponseVerifier.verifyGenreDto("._embedded.data[1]", resultActions, genreDto2);
     }
 
     @Test
@@ -483,8 +483,8 @@ public class GenreControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGenreDto("._embedded.genreDtoes[0]", resultActions, genreDto1);
-        ResponseVerifier.verifyGenreDto("._embedded.genreDtoes[1]", resultActions, genreDto2);
+        ResponseVerifier.verifyGenreDto("._embedded.data[0]", resultActions, genreDto1);
+        ResponseVerifier.verifyGenreDto("._embedded.data[1]", resultActions, genreDto2);
     }
 
     @Test

--- a/game-server/src/test/java/com/traklibrary/game/server/controller/PlatformControllerTest.java
+++ b/game-server/src/test/java/com/traklibrary/game/server/controller/PlatformControllerTest.java
@@ -201,8 +201,8 @@ public class PlatformControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGameDto("._embedded.gameDtoes[0]", resultActions, gameDto1);
-        ResponseVerifier.verifyGameDto("._embedded.gameDtoes[1]", resultActions, gameDto2);
+        ResponseVerifier.verifyGameDto("._embedded.data[0]", resultActions, gameDto1);
+        ResponseVerifier.verifyGameDto("._embedded.data[1]", resultActions, gameDto2);
     }
 
     @Test
@@ -246,8 +246,8 @@ public class PlatformControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGameDto("._embedded.gameDtoes[0]", resultActions, gameDto1);
-        ResponseVerifier.verifyGameDto("._embedded.gameDtoes[1]", resultActions, gameDto2);
+        ResponseVerifier.verifyGameDto("._embedded.data[0]", resultActions, gameDto1);
+        ResponseVerifier.verifyGameDto("._embedded.data[1]", resultActions, gameDto2);
     }
 
     @Test
@@ -316,8 +316,8 @@ public class PlatformControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyPlatformDto("._embedded.platformDtoes[0]", resultActions, platformDto1);
-        ResponseVerifier.verifyPlatformDto("._embedded.platformDtoes[1]", resultActions, platformDto2);
+        ResponseVerifier.verifyPlatformDto("._embedded.data[0]", resultActions, platformDto1);
+        ResponseVerifier.verifyPlatformDto("._embedded.data[1]", resultActions, platformDto2);
     }
 
     @Test
@@ -359,8 +359,8 @@ public class PlatformControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyPlatformDto("._embedded.platformDtoes[0]", resultActions, platformDto1);
-        ResponseVerifier.verifyPlatformDto("._embedded.platformDtoes[1]", resultActions, platformDto2);
+        ResponseVerifier.verifyPlatformDto("._embedded.data[0]", resultActions, platformDto1);
+        ResponseVerifier.verifyPlatformDto("._embedded.data[1]", resultActions, platformDto2);
     }
 
     @Test

--- a/game-server/src/test/java/com/traklibrary/game/server/controller/PublisherControllerTest.java
+++ b/game-server/src/test/java/com/traklibrary/game/server/controller/PublisherControllerTest.java
@@ -202,8 +202,8 @@ class PublisherControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGameDto("._embedded.gameDtoes[0]", resultActions, gameDto1);
-        ResponseVerifier.verifyGameDto("._embedded.gameDtoes[1]", resultActions, gameDto2);
+        ResponseVerifier.verifyGameDto("._embedded.data[0]", resultActions, gameDto1);
+        ResponseVerifier.verifyGameDto("._embedded.data[1]", resultActions, gameDto2);
     }
 
     @Test
@@ -247,8 +247,8 @@ class PublisherControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyGameDto("._embedded.gameDtoes[0]", resultActions, gameDto1);
-        ResponseVerifier.verifyGameDto("._embedded.gameDtoes[1]", resultActions, gameDto2);
+        ResponseVerifier.verifyGameDto("._embedded.data[0]", resultActions, gameDto1);
+        ResponseVerifier.verifyGameDto("._embedded.data[1]", resultActions, gameDto2);
     }
 
     @Test
@@ -317,8 +317,8 @@ class PublisherControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyPublisherDto("._embedded.publisherDtoes[0]", resultActions, publisherDto1);
-        ResponseVerifier.verifyPublisherDto("._embedded.publisherDtoes[1]", resultActions, publisherDto2);
+        ResponseVerifier.verifyPublisherDto("._embedded.data[0]", resultActions, publisherDto1);
+        ResponseVerifier.verifyPublisherDto("._embedded.data[1]", resultActions, publisherDto2);
     }
 
     @Test
@@ -360,8 +360,8 @@ class PublisherControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
 
-        ResponseVerifier.verifyPublisherDto("._embedded.publisherDtoes[0]", resultActions, publisherDto1);
-        ResponseVerifier.verifyPublisherDto("._embedded.publisherDtoes[1]", resultActions, publisherDto2);
+        ResponseVerifier.verifyPublisherDto("._embedded.data[0]", resultActions, publisherDto1);
+        ResponseVerifier.verifyPublisherDto("._embedded.data[1]", resultActions, publisherDto2);
     }
 
     @Test

--- a/game-service/src/main/java/com/traklibrary/game/service/dto/GameInfoDto.java
+++ b/game-service/src/main/java/com/traklibrary/game/service/dto/GameInfoDto.java
@@ -7,6 +7,7 @@ import org.springframework.hateoas.server.core.Relation;
 import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 
 @Data
 @Relation(collectionRelation = "data", itemRelation = "gameInfo")
@@ -24,9 +25,9 @@ public class GameInfoDto {
 
     private Long version;
 
-    private Set<PlatformDto> platforms = new HashSet<>();
+    private Set<PlatformDto> platforms = new TreeSet<>();
 
-    private Set<PublisherDto> publishers = new HashSet<>();
+    private Set<PublisherDto> publishers = new TreeSet<>();
 
-    private Set<GenreDto> genres = new HashSet<>();
+    private Set<GenreDto> genres = new TreeSet<>();
 }

--- a/game-service/src/main/java/com/traklibrary/game/service/dto/GameInfoDto.java
+++ b/game-service/src/main/java/com/traklibrary/game/service/dto/GameInfoDto.java
@@ -5,7 +5,6 @@ import lombok.Data;
 import org.springframework.hateoas.server.core.Relation;
 
 import java.time.LocalDate;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
 

--- a/game-service/src/main/java/com/traklibrary/game/service/dto/GameUserEntryDto.java
+++ b/game-service/src/main/java/com/traklibrary/game/service/dto/GameUserEntryDto.java
@@ -32,7 +32,7 @@ public class GameUserEntryDto {
     @NotNull(message = "{game-user-entry.validation.status.not-null}")
     private GameUserEntryStatus status;
 
-    private Collection<PublisherDto> publishers = new ArrayList<>();
+    private Collection<String> publishers = new ArrayList<>();
 
     @Min(message = "{game-user-entry.validation.rating.min}", value = 0)
     @Max(message = "{game-user-entry.validation.rating.max}", value = 5)

--- a/game-service/src/main/java/com/traklibrary/game/service/dto/GenreDto.java
+++ b/game-service/src/main/java/com/traklibrary/game/service/dto/GenreDto.java
@@ -1,5 +1,7 @@
 package com.traklibrary.game.service.dto;
 
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.Ordering;
 import lombok.Data;
 import org.springframework.hateoas.server.core.Relation;
 
@@ -8,7 +10,7 @@ import javax.validation.constraints.Size;
 
 @Data
 @Relation(collectionRelation = "data", itemRelation = "genre")
-public class GenreDto {
+public class GenreDto implements Comparable<GenreDto> {
 
     private long id;
 
@@ -19,4 +21,25 @@ public class GenreDto {
     private String description;
 
     private Long version;
+
+    /**
+     * Used for comparison between two {@link GenreDto} objects. It's used
+     * internally whenever a {@link GenreDto} is the type within a list which
+     * supported inserted sort, such as a {@link java.util.TreeSet}.
+     *
+     * The order in which {@link GenreDto} instances are sorted are by {@link GenreDto#name}
+     * and {@link GenreDto#id}.
+     *
+     * @param other The other {@link GenreDto} instance to compare against.
+     *
+     * @return a negative integer, zero, or a positive integer as this {@link GenreDto}
+     *         is less than, equal to, or greater than the specified object.
+     */
+    @Override
+    public int compareTo(GenreDto other) {
+        return ComparisonChain.start()
+                .compare(name, other.name, Ordering.natural().nullsLast())
+                .compare(id, other.id)
+                .result();
+    }
 }

--- a/game-service/src/main/java/com/traklibrary/game/service/dto/PlatformDto.java
+++ b/game-service/src/main/java/com/traklibrary/game/service/dto/PlatformDto.java
@@ -1,5 +1,7 @@
 package com.traklibrary.game.service.dto;
 
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.Ordering;
 import lombok.Data;
 import org.springframework.hateoas.server.core.Relation;
 
@@ -9,7 +11,7 @@ import java.time.LocalDate;
 
 @Data
 @Relation(collectionRelation = "data", itemRelation = "platform")
-public class PlatformDto {
+public class PlatformDto implements Comparable<PlatformDto> {
 
     private long id;
 
@@ -22,4 +24,26 @@ public class PlatformDto {
     private LocalDate releaseDate;
 
     private Long version;
+
+    /**
+     * Used for comparison between two {@link PlatformDto} objects. It's used
+     * internally whenever a {@link PlatformDto} is the type within a list which
+     * supported inserted sort, such as a {@link java.util.TreeSet}.
+     *
+     * The order in which {@link PlatformDto} instances are sorted are by {@link PlatformDto#name},
+     * {@link PlatformDto#releaseDate} and finally {@link PlatformDto#id}.
+     *
+     * @param other The other {@link PlatformDto} instance to compare against.
+     *
+     * @return  a negative integer, zero, or a positive integer as this {@link PlatformDto}
+     *          is less than, equal to, or greater than the specified object.
+     */
+    @Override
+    public int compareTo(PlatformDto other) {
+        return ComparisonChain.start()
+                .compare(name, other.name, Ordering.natural().nullsLast())
+                .compare(releaseDate, other.releaseDate, Ordering.natural().nullsLast())
+                .compare(id, other.id)
+                .result();
+    }
 }

--- a/game-service/src/main/java/com/traklibrary/game/service/dto/PublisherDto.java
+++ b/game-service/src/main/java/com/traklibrary/game/service/dto/PublisherDto.java
@@ -1,5 +1,7 @@
 package com.traklibrary.game.service.dto;
 
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.Ordering;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.springframework.hateoas.server.core.Relation;
@@ -7,5 +9,27 @@ import org.springframework.hateoas.server.core.Relation;
 @EqualsAndHashCode(callSuper = true)
 @Data
 @Relation(collectionRelation = "data", itemRelation = "publisher")
-public class PublisherDto extends CompanyDto {
+public class PublisherDto extends CompanyDto implements Comparable<PublisherDto> {
+
+    /**
+     * Used for comparison between two {@link PublisherDto} objects. It's used
+     * internally whenever a {@link PublisherDto} is the type within a list which
+     * supported inserted sort, such as a {@link java.util.TreeSet}.
+     *
+     * The order in which {@link PlatformDto} instances are sorted are by {@link PublisherDto#getName()},
+     * {@link PublisherDto#getFoundedDate()} and finally {@link PublisherDto#getId()}.
+     *
+     * @param other The other {@link PublisherDto} instance to compare against.
+     *
+     * @return A negative integer, zero, or a positive integer as this {@link PublisherDto}
+     *         is less than, equal to, or greater than the specified object.
+     */
+    @Override
+    public int compareTo(PublisherDto other) {
+        return ComparisonChain.start()
+                .compare(getName(), other.getName(), Ordering.natural().nullsLast())
+                .compare(getFoundedDate(), other.getFoundedDate(), Ordering.natural().nullsLast())
+                .compare(getId(), other.getId())
+                .result();
+    }
 }

--- a/game-service/src/main/java/com/traklibrary/game/service/mapper/GameUserEntryMapper.java
+++ b/game-service/src/main/java/com/traklibrary/game/service/mapper/GameUserEntryMapper.java
@@ -3,7 +3,6 @@ package com.traklibrary.game.service.mapper;
 import com.traklibrary.game.domain.GameUserEntry;
 import com.traklibrary.game.domain.Publisher;
 import com.traklibrary.game.service.dto.GameUserEntryDto;
-import com.traklibrary.game.service.dto.PublisherDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 

--- a/game-service/src/main/java/com/traklibrary/game/service/mapper/GameUserEntryMapper.java
+++ b/game-service/src/main/java/com/traklibrary/game/service/mapper/GameUserEntryMapper.java
@@ -20,7 +20,7 @@ public interface GameUserEntryMapper {
     @Mapping(target = "platform", ignore = true)
     GameUserEntry gameUserEntryDtoToGameUserEntry(GameUserEntryDto gameUserEntryDto);
 
-    default PublisherDto publisherToPublisherDto(Publisher publisher) {
-        return GameMappers.PUBLISHER_MAPPER.publisherToPublisherDto(publisher);
+    default String publisherToPublisherName(Publisher publisher) {
+        return publisher.getName();
     }
 }

--- a/game-service/src/test/java/com/traklibrary/game/service/dto/GenreDtoTest.java
+++ b/game-service/src/test/java/com/traklibrary/game/service/dto/GenreDtoTest.java
@@ -1,0 +1,79 @@
+package com.traklibrary.game.service.dto;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class GenreDtoTest {
+
+    @Test
+    void compareTo_withNullName_returnsCorrectComparison() {
+        // Arrange
+        GenreDto genreDto = new GenreDto();
+        genreDto.setId(5L);
+        genreDto.setName("A");
+
+        GenreDto comparison = new GenreDto();
+        comparison.setId(4L);
+        comparison.setName(null);
+
+        // Act
+        int result = genreDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    void compareTo_withAscendingName_returnsCorrectComparison() {
+        // Arrange
+        GenreDto genreDto = new GenreDto();
+        genreDto.setId(5L);
+        genreDto.setName("A");
+
+        GenreDto comparison = new GenreDto();
+        comparison.setId(4L);
+        comparison.setName("B");
+
+        // Act
+        int result = genreDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(-1);
+    }
+    
+    @Test
+    void compareTo_withAscendingId_returnsCorrectComparison() {
+        // Arrange
+        GenreDto genreDto = new GenreDto();
+        genreDto.setId(4L);
+        genreDto.setName("A");
+
+        GenreDto comparison = new GenreDto();
+        comparison.setId(5L);
+        comparison.setName("A");
+
+        // Act
+        int result = genreDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    void compareTo_withMatchingPlatforms_returnsCorrectComparison() {
+        // Arrange
+        GenreDto genreDto = new GenreDto();
+        genreDto.setId(5L);
+        genreDto.setName("A");
+
+        GenreDto comparison = new GenreDto();
+        comparison.setId(5L);
+        comparison.setName("A");
+
+        // Act
+        int result = genreDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(0);
+    }
+}

--- a/game-service/src/test/java/com/traklibrary/game/service/dto/GenreDtoTest.java
+++ b/game-service/src/test/java/com/traklibrary/game/service/dto/GenreDtoTest.java
@@ -74,6 +74,6 @@ class GenreDtoTest {
         int result = genreDto.compareTo(comparison);
 
         // Assert
-        Assertions.assertThat(result).isEqualTo(0);
+        Assertions.assertThat(result).isZero();
     }
 }

--- a/game-service/src/test/java/com/traklibrary/game/service/dto/PlatformDtoTest.java
+++ b/game-service/src/test/java/com/traklibrary/game/service/dto/PlatformDtoTest.java
@@ -124,6 +124,6 @@ class PlatformDtoTest {
         int result = platformDto.compareTo(comparison);
 
         // Assert
-        Assertions.assertThat(result).isEqualTo(0);
+        Assertions.assertThat(result).isZero();
     }
 }

--- a/game-service/src/test/java/com/traklibrary/game/service/dto/PlatformDtoTest.java
+++ b/game-service/src/test/java/com/traklibrary/game/service/dto/PlatformDtoTest.java
@@ -1,0 +1,129 @@
+package com.traklibrary.game.service.dto;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+class PlatformDtoTest {
+
+    @Test
+    void compareTo_withNullName_returnsCorrectComparison() {
+        // Arrange
+        PlatformDto platformDto = new PlatformDto();
+        platformDto.setId(5L);
+        platformDto.setName("A");
+        platformDto.setReleaseDate(LocalDate.now().plusDays(1));
+
+        PlatformDto comparison = new PlatformDto();
+        comparison.setId(4L);
+        comparison.setName(null);
+        comparison.setReleaseDate(LocalDate.now());
+
+        // Act
+        int result = platformDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    void compareTo_withAscendingName_returnsCorrectComparison() {
+        // Arrange
+        PlatformDto platformDto = new PlatformDto();
+        platformDto.setId(5L);
+        platformDto.setName("A");
+        platformDto.setReleaseDate(LocalDate.now().plusDays(1));
+
+        PlatformDto comparison = new PlatformDto();
+        comparison.setId(4L);
+        comparison.setName("B");
+        comparison.setReleaseDate(LocalDate.now());
+
+        // Act
+        int result = platformDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    void compareTo_withNullReleaseDate_returnsCorrectComparison() {
+        // Arrange
+        PlatformDto platformDto = new PlatformDto();
+        platformDto.setId(5L);
+        platformDto.setName("A");
+        platformDto.setReleaseDate(LocalDate.now().plusDays(1));
+
+        PlatformDto comparison = new PlatformDto();
+        comparison.setId(4L);
+        comparison.setName("A");
+        comparison.setReleaseDate(null);
+
+        // Act
+        int result = platformDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    void compareTo_withAscendingReleaseDate_returnsCorrectComparison() {
+        // Arrange
+        PlatformDto platformDto = new PlatformDto();
+        platformDto.setId(5L);
+        platformDto.setName("A");
+        platformDto.setReleaseDate(LocalDate.now());
+
+        PlatformDto comparison = new PlatformDto();
+        comparison.setId(4L);
+        comparison.setName("A");
+        comparison.setReleaseDate(LocalDate.now().plusDays(1));
+
+        // Act
+        int result = platformDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    void compareTo_withAscendingId_returnsCorrectComparison() {
+        // Arrange
+        PlatformDto platformDto = new PlatformDto();
+        platformDto.setId(4L);
+        platformDto.setName("A");
+        platformDto.setReleaseDate(LocalDate.now());
+
+        PlatformDto comparison = new PlatformDto();
+        comparison.setId(5L);
+        comparison.setName("A");
+        comparison.setReleaseDate(LocalDate.now());
+
+        // Act
+        int result = platformDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    void compareTo_withMatchingPlatforms_returnsCorrectComparison() {
+        // Arrange
+        PlatformDto platformDto = new PlatformDto();
+        platformDto.setId(5L);
+        platformDto.setName("A");
+        platformDto.setReleaseDate(LocalDate.now());
+
+        PlatformDto comparison = new PlatformDto();
+        comparison.setId(5L);
+        comparison.setName("A");
+        comparison.setReleaseDate(LocalDate.now());
+
+        // Act
+        int result = platformDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(0);
+    }
+}

--- a/game-service/src/test/java/com/traklibrary/game/service/dto/PublisherDtoTest.java
+++ b/game-service/src/test/java/com/traklibrary/game/service/dto/PublisherDtoTest.java
@@ -124,6 +124,6 @@ class PublisherDtoTest {
         int result = publisherDto.compareTo(comparison);
 
         // Assert
-        Assertions.assertThat(result).isEqualTo(0);
+        Assertions.assertThat(result).isZero();
     }
 }

--- a/game-service/src/test/java/com/traklibrary/game/service/dto/PublisherDtoTest.java
+++ b/game-service/src/test/java/com/traklibrary/game/service/dto/PublisherDtoTest.java
@@ -1,0 +1,129 @@
+package com.traklibrary.game.service.dto;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+class PublisherDtoTest {
+
+    @Test
+    void compareTo_withNullName_returnsCorrectComparison() {
+        // Arrange
+        PublisherDto publisherDto = new PublisherDto();
+        publisherDto.setId(5L);
+        publisherDto.setName("A");
+        publisherDto.setFoundedDate(LocalDate.now().plusDays(1));
+
+        PublisherDto comparison = new PublisherDto();
+        comparison.setId(4L);
+        comparison.setName(null);
+        comparison.setFoundedDate(LocalDate.now());
+
+        // Act
+        int result = publisherDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    void compareTo_withAscendingName_returnsCorrectComparison() {
+        // Arrange
+        PublisherDto publisherDto = new PublisherDto();
+        publisherDto.setId(5L);
+        publisherDto.setName("A");
+        publisherDto.setFoundedDate(LocalDate.now().plusDays(1));
+
+        PublisherDto comparison = new PublisherDto();
+        comparison.setId(4L);
+        comparison.setName("B");
+        comparison.setFoundedDate(LocalDate.now());
+
+        // Act
+        int result = publisherDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    void compareTo_withNullFoundedDate_returnsCorrectComparison() {
+        // Arrange
+        PublisherDto publisherDto = new PublisherDto();
+        publisherDto.setId(5L);
+        publisherDto.setName("A");
+        publisherDto.setFoundedDate(LocalDate.now().plusDays(1));
+
+        PublisherDto comparison = new PublisherDto();
+        comparison.setId(4L);
+        comparison.setName("A");
+        comparison.setFoundedDate(null);
+
+        // Act
+        int result = publisherDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    void compareTo_withAscendingFoundedDate_returnsCorrectComparison() {
+        // Arrange
+        PublisherDto publisherDto = new PublisherDto();
+        publisherDto.setId(5L);
+        publisherDto.setName("A");
+        publisherDto.setFoundedDate(LocalDate.now());
+
+        PublisherDto comparison = new PublisherDto();
+        comparison.setId(4L);
+        comparison.setName("A");
+        comparison.setFoundedDate(LocalDate.now().plusDays(1));
+
+        // Act
+        int result = publisherDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    void compareTo_withAscendingId_returnsCorrectComparison() {
+        // Arrange
+        PublisherDto publisherDto = new PublisherDto();
+        publisherDto.setId(4L);
+        publisherDto.setName("A");
+        publisherDto.setFoundedDate(LocalDate.now());
+
+        PublisherDto comparison = new PublisherDto();
+        comparison.setId(5L);
+        comparison.setName("A");
+        comparison.setFoundedDate(LocalDate.now());
+
+        // Act
+        int result = publisherDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    void compareTo_withMatchingPlatforms_returnsCorrectComparison() {
+        // Arrange
+        PublisherDto publisherDto = new PublisherDto();
+        publisherDto.setId(5L);
+        publisherDto.setName("A");
+        publisherDto.setFoundedDate(LocalDate.now());
+
+        PublisherDto comparison = new PublisherDto();
+        comparison.setId(5L);
+        comparison.setName("A");
+        comparison.setFoundedDate(LocalDate.now());
+
+        // Act
+        int result = publisherDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(0);
+    }
+}

--- a/game-service/src/test/java/com/traklibrary/game/service/mapper/GameUserEntryMapperTest.java
+++ b/game-service/src/test/java/com/traklibrary/game/service/mapper/GameUserEntryMapperTest.java
@@ -32,7 +32,7 @@ class GameUserEntryMapperTest {
 
         Platform platform = new Platform();
         platform.setName("test-name");
-
+d1
         GameUserEntry gameUserEntry = new GameUserEntry();
         gameUserEntry.setId(5L);
         gameUserEntry.setGameId(6L);
@@ -53,7 +53,7 @@ class GameUserEntryMapperTest {
         Assertions.assertEquals(gameUserEntry.getGame().getReleaseDate(), result.getGameReleaseDate(), "The mapped game release date does not match the entity.");
         Assertions.assertEquals(gameUserEntry.getPlatformId(), result.getPlatformId(), "The mapped platform ID does not match the entity.");
         Assertions.assertEquals(gameUserEntry.getPlatform().getName(), result.getPlatformName(), "The mapped platform name does not match the entity.");
-        Assertions.assertEquals(publisher.getName(), result.getPublishers().iterator().next().getName(), "The mapped publisher does not match the entity.");
+        Assertions.assertEquals(publisher.getName(), result.getPublishers().iterator().next(), "The mapped publisher does not match the entity.");
         Assertions.assertEquals(gameUserEntry.getUserId(), result.getUserId(), "The mapped user ID does not match the entity.");
         Assertions.assertEquals(gameUserEntry.getStatus(), result.getStatus(), "The mapped status does not match the entity.");
         Assertions.assertEquals(gameUserEntry.getRating(), result.getRating(), "The mapped rating does not match the entity.");

--- a/game-service/src/test/java/com/traklibrary/game/service/mapper/GameUserEntryMapperTest.java
+++ b/game-service/src/test/java/com/traklibrary/game/service/mapper/GameUserEntryMapperTest.java
@@ -32,7 +32,7 @@ class GameUserEntryMapperTest {
 
         Platform platform = new Platform();
         platform.setName("test-name");
-d1
+
         GameUserEntry gameUserEntry = new GameUserEntry();
         gameUserEntry.setId(5L);
         gameUserEntry.setGameId(6L);


### PR DESCRIPTION
- Changed hal configuration to correctly render objects with the relation annotation.
- Fixed the unit tests broken by this change.
- Implemented Comparable for the genre, platform and publisher classes, as they're now stored within tree sets on the GameInfo object.
- Added unit tests for the sorting.
- Removed PublisherDto's from the GameUserEntryDto and gone back to just mapping the name of the publisher.
- Fixed mapper test to reflect change.
- Changed buildspec to analyze develop branch when the pull request has been merged.