### PR TITLE
APP-20: Allow users to change their password.

### DIFF
--- a/auth-server/src/main/java/com/traklibrary/authentication/server/controller/UserController.java
+++ b/auth-server/src/main/java/com/traklibrary/authentication/server/controller/UserController.java
@@ -130,4 +130,37 @@ public class UserController {
     public void requestRecovery(@RequestParam("email-address") String emailAddress) {
         userService.requestRecovery(emailAddress);
     }
+
+    /**
+     * End-point that is used when a user first requests that they wish to change the password of their account. This end-point will not
+     * change their password, instead this will send an email to the email address associated with their account containing a recovery token
+     * that will have to be entered alongside the new password they want when requesting for it to be changed.
+     *
+     * Similar to other end-points, the user can only request a change password email if they have the correct authentication for the account
+     * they're requesting the email for, they cannot request for an account they are not associated with unless they have elevated privileges.
+     *
+     * @param username The name of the username to send the change password email to.
+     */
+    @AllowedForUser
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PutMapping("/{username}/request-change-password")
+    public void requestChangePassword(@PathVariable String username) {
+        userService.requestChangePassword(username);
+    }
+
+    /**
+     * End-point that is used when a user wants to change their password. When the user wishes to change their password, they must send
+     * their current username and their recovery token, which should have been emailed to their account when the {@link UserController#requestChangePassword(String)}
+     * was invoked. Without this second layer of authentication, the user cannot their their password.
+     *
+     * Similar to other end-points, the user can only request a change password email if they have the correct authentication for the account
+     * they're requesting the email for, they cannot request for an account they are not associated with unless they have elevated privileges.
+     *
+     * @param changePasswordRequestDto The DTO that contains the user's new requested password and the emailed recovery token.
+     */
+    @AllowedForUser
+    @PutMapping("/change-password")
+    public CheckedResponse<Boolean> changePassword(@Validated @RequestBody ChangePasswordRequestDto changePasswordRequestDto) {
+        return userService.changePassword(changePasswordRequestDto);
+    }
 }

--- a/auth-server/src/main/java/com/traklibrary/authentication/server/exception/GlobalExceptionHandler.java
+++ b/auth-server/src/main/java/com/traklibrary/authentication/server/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.traklibrary.authentication.server.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpHeaders;
@@ -31,6 +32,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         ApiError apiError = new ApiError(HttpStatus.NOT_FOUND);
         apiError.setMessage(ex.getMessage());
+        apiError.setDebugMessage(ExceptionUtils.getStackTrace(ex));
 
         return new ResponseEntity<>(apiError, HttpStatus.NOT_FOUND);
     }
@@ -41,6 +43,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         ApiError apiError = new ApiError(HttpStatus.BAD_REQUEST);
         apiError.setMessage(ex.getMessage());
+        apiError.setDebugMessage(ExceptionUtils.getStackTrace(ex));
 
         return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
     }
@@ -52,6 +55,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         ApiError apiError = new ApiError(HttpStatus.BAD_REQUEST);
         apiError.setMessage(ex.getMessage());
+        apiError.setDebugMessage(ExceptionUtils.getStackTrace(ex));
 
         return new ResponseEntity<>(apiError, headers, status);
     }
@@ -63,6 +67,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         ApiError apiError = new ApiError(HttpStatus.BAD_REQUEST);
         apiError.setMessage(ex.getMessage());
+        apiError.setDebugMessage(ExceptionUtils.getStackTrace(ex));
 
         // Stream through each sub-error and add all of them to the response.
         apiError.getSubErrors().addAll(ex.getBindingResult().getFieldErrors()
@@ -79,6 +84,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         ApiError apiError = new ApiError(HttpStatus.BAD_REQUEST);
         apiError.setMessage(ex.getMessage());
+        apiError.setDebugMessage(ExceptionUtils.getStackTrace(ex));
 
         apiError.getSubErrors().addAll(ex.getConstraintViolations()
                 .stream()

--- a/auth-server/src/main/resources/i18n/validation.properties
+++ b/auth-server/src/main/resources/i18n/validation.properties
@@ -1,3 +1,8 @@
+change-password-request.validation.username.not-empty=The username cannot be empty or null.
+change-password-request.validation.recovery-token.not-empty=The recovery token cannot be empty or null.
+change-password-request.validation.recovery-token.size=The recovery token should be exactly 30 characters in length.
+change-password-request.validation.new-password.invalid=The password does not match the password criteria.
+
 recovery-request.validation.username.not-empty=The username cannot be empty or null.
 recovery-request.validation.recovery-token.not-empty=The recovery token cannot be empty or null.
 recovery-request.validation.recovery-token.size=The recovery token should be exactly 30 characters in length.

--- a/auth-server/src/main/resources/i18n/validation_en.properties
+++ b/auth-server/src/main/resources/i18n/validation_en.properties
@@ -1,3 +1,8 @@
+change-password-request.validation.username.not-empty=The username cannot be empty or null.
+change-password-request.validation.recovery-token.not-empty=The recovery token cannot be empty or null.
+change-password-request.validation.recovery-token.size=The recovery token should be exactly 30 characters in length.
+change-password-request.validation.new-password.invalid=The password does not match the password criteria.
+
 recovery-request.validation.username.not-empty=The username cannot be empty or null.
 recovery-request.validation.recovery-token.not-empty=The recovery token cannot be empty or null.
 recovery-request.validation.recovery-token.size=The recovery token should be exactly 30 characters in length.

--- a/auth-service/src/main/java/com/traklibrary/authentication/service/UserService.java
+++ b/auth-service/src/main/java/com/traklibrary/authentication/service/UserService.java
@@ -1,9 +1,6 @@
 package com.traklibrary.authentication.service;
 
-import com.traklibrary.authentication.service.dto.CheckedResponse;
-import com.traklibrary.authentication.service.dto.RecoveryRequestDto;
-import com.traklibrary.authentication.service.dto.RegistrationRequestDto;
-import com.traklibrary.authentication.service.dto.UserResponseDto;
+import com.traklibrary.authentication.service.dto.*;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
 public interface UserService extends UserDetailsService {
@@ -23,4 +20,8 @@ public interface UserService extends UserDetailsService {
     void reverify(String username);
 
     void requestRecovery(String emailAddress);
+
+    void requestChangePassword(String username);
+
+    CheckedResponse<Boolean> changePassword(ChangePasswordRequestDto changePasswordRequestDto);
 }

--- a/auth-service/src/main/java/com/traklibrary/authentication/service/client/EmailClient.java
+++ b/auth-service/src/main/java/com/traklibrary/authentication/service/client/EmailClient.java
@@ -5,4 +5,6 @@ public interface EmailClient {
     void sendVerificationEmail(String emailAddress, String verificationCode);
 
     void sendRecoveryEmail(String emailAddress, String recoveryToken);
+
+    void sendChangePasswordEmail(String emailAddress, String recoveryToken);
 }

--- a/auth-service/src/main/java/com/traklibrary/authentication/service/configuration/SpringResilienceConfiguration.java
+++ b/auth-service/src/main/java/com/traklibrary/authentication/service/configuration/SpringResilienceConfiguration.java
@@ -16,7 +16,7 @@ public class SpringResilienceConfiguration {
     @Bean
     public Customizer<Resilience4JCircuitBreakerFactory> resilience4JCircuitBreakerFactoryCustomizer() {
         return factory -> factory.configureDefault(id -> new Resilience4JConfigBuilder(id)
-                    .timeLimiterConfig(TimeLimiterConfig.custom().timeoutDuration(Duration.ofSeconds(4)).build())
+                    .timeLimiterConfig(TimeLimiterConfig.custom().timeoutDuration(Duration.ofSeconds(60)).build())
                     .circuitBreakerConfig(CircuitBreakerConfig.ofDefaults())
                     .build());
     }

--- a/auth-service/src/main/java/com/traklibrary/authentication/service/dto/ChangePasswordRequestDto.java
+++ b/auth-service/src/main/java/com/traklibrary/authentication/service/dto/ChangePasswordRequestDto.java
@@ -1,0 +1,21 @@
+package com.traklibrary.authentication.service.dto;
+
+import com.traklibrary.authentication.service.validation.ValidPassword;
+import lombok.Data;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
+
+@Data
+public class ChangePasswordRequestDto {
+
+    @NotEmpty(message = "{change-password-request.validation.username.not-empty}")
+    private String username;
+
+    @NotEmpty(message = "{change-password-request.validation.recovery-token.not-empty}")
+    @Size(min = 30, max = 30, message = "{change-password-request.validation.recovery-token.size}")
+    private String recoveryToken;
+
+    @ValidPassword(message = "{change-password-request.validation.new-password.invalid}")
+    private String newPassword;
+}

--- a/auth-service/src/main/java/com/traklibrary/authentication/service/event/OnChangePasswordEvent.java
+++ b/auth-service/src/main/java/com/traklibrary/authentication/service/event/OnChangePasswordEvent.java
@@ -1,0 +1,19 @@
+package com.traklibrary.authentication.service.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+public class OnChangePasswordEvent extends ApplicationEvent {
+
+    @Getter
+    private final String emailAddress;
+
+    @Getter
+    private final String username;
+
+    public OnChangePasswordEvent(Object source, String emailAddress, String username) {
+        super(source);
+        this.emailAddress = emailAddress;
+        this.username = username;
+    }
+}

--- a/auth-service/src/main/java/com/traklibrary/authentication/service/listener/ChangePasswordEventListener.java
+++ b/auth-service/src/main/java/com/traklibrary/authentication/service/listener/ChangePasswordEventListener.java
@@ -1,0 +1,27 @@
+package com.traklibrary.authentication.service.listener;
+
+import com.google.common.base.Strings;
+import com.traklibrary.authentication.service.UserService;
+import com.traklibrary.authentication.service.client.EmailClient;
+import com.traklibrary.authentication.service.event.OnChangePasswordEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class ChangePasswordEventListener implements ApplicationListener<OnChangePasswordEvent> {
+
+    private final UserService userService;
+    private final EmailClient emailClient;
+
+    @Override
+    public void onApplicationEvent(OnChangePasswordEvent onChangePasswordEvent) {
+        // Creates and persists a new recovery token for the given user.
+        String recoveryToken = userService.createRecoveryToken(onChangePasswordEvent.getUsername());
+        // Only send the recovery token email if a new valid token has been created.
+        if (!Strings.isNullOrEmpty(recoveryToken)) {
+            emailClient.sendChangePasswordEmail(onChangePasswordEvent.getEmailAddress(), recoveryToken);
+        }
+    }
+}

--- a/auth-service/src/test/java/com/traklibrary/authentication/service/listener/ChangePasswordEventListenerTest.java
+++ b/auth-service/src/test/java/com/traklibrary/authentication/service/listener/ChangePasswordEventListenerTest.java
@@ -1,0 +1,73 @@
+package com.traklibrary.authentication.service.listener;
+
+import com.traklibrary.authentication.service.UserService;
+import com.traklibrary.authentication.service.client.EmailClient;
+import com.traklibrary.authentication.service.event.OnChangePasswordEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChangePasswordEventListenerTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private EmailClient emailClient;
+
+    @InjectMocks
+    private ChangePasswordEventListener changePasswordEventListener;
+
+    @Test
+    void onApplicationEvent_withNullRecoveryToken_doesntInvokeEmailClient() {
+        // Arrange
+        OnChangePasswordEvent onChangePasswordEvent = new OnChangePasswordEvent(this, "test@traklibrary.com", "username");
+
+        Mockito.when(userService.createRecoveryToken(ArgumentMatchers.anyString()))
+                .thenReturn(null);
+
+        // Act
+        changePasswordEventListener.onApplicationEvent(onChangePasswordEvent);
+
+        // Assert
+        Mockito.verify(emailClient, Mockito.never())
+                .sendChangePasswordEmail(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void onApplicationEvent_withEmptyRecoveryToken_doesntInvokeEmailClient() {
+        // Arrange
+        OnChangePasswordEvent onChangePasswordEvent = new OnChangePasswordEvent(this, "test@traklibrary.com", "username");
+
+        Mockito.when(userService.createRecoveryToken(ArgumentMatchers.anyString()))
+                .thenReturn("");
+
+        // Act
+        changePasswordEventListener.onApplicationEvent(onChangePasswordEvent);
+
+        // Assert
+        Mockito.verify(emailClient, Mockito.never())
+                .sendChangePasswordEmail(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void onApplicationEvent_withValidRecoveryToken_invokesEmailClient() {
+        // Arrange
+        OnChangePasswordEvent onChangePasswordEvent = new OnChangePasswordEvent(this, "test@traklibrary.com", "username");
+
+        Mockito.when(userService.createRecoveryToken(ArgumentMatchers.anyString()))
+                .thenReturn("recovery-token");
+
+        // Act
+        changePasswordEventListener.onApplicationEvent(onChangePasswordEvent);
+
+        // Assert
+        Mockito.verify(emailClient, Mockito.atMostOnce())
+                .sendChangePasswordEmail(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
+    }
+}

--- a/email-server/src/main/java/com/traklibrary/email/server/controller/EmailController.java
+++ b/email-server/src/main/java/com/traklibrary/email/server/controller/EmailController.java
@@ -61,4 +61,23 @@ public class EmailController {
                                   @RequestParam("recovery-token") String recoveryToken) {
         emailService.sendRecoveryEmail(emailAddress, recoveryToken);
     }
+
+    /**
+     * End-point that will dispatch a change password email to the given email address. When the service method is invoked
+     * by the end-point, it will verify that the email address matches the currently authenticated user, this is to
+     * prevent the end-point from being used to send emails to random accounts when the user does not have permission
+     * to do so.
+     *
+     * If the email is sent successfully, the end-point will return a 204 response code, otherwise if any issues
+     * occurred a {@link EmailFailedException} will be thrown.
+     *
+     * @param emailAddress The email address to dispatch the change password email to.
+     * @param recoveryToken The randomly generated password of the user to attach to the email.
+     */
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PutMapping("/change-password")
+    public void sendChangePasswordEmail(@RequestParam("email-address") String emailAddress,
+                                        @RequestParam("recovery-token") String recoveryToken) {
+        emailService.sendChangePasswordEmail(emailAddress, recoveryToken);
+    }
 }

--- a/email-server/src/main/resources/i18n/messages.properties
+++ b/email-server/src/main/resources/i18n/messages.properties
@@ -1,3 +1,5 @@
+email.change-password.subject=Change password.
+
 email.recovery.subject=Reset password.
 
 email.verification.welcome=Welcome to

--- a/email-server/src/main/resources/i18n/messages_en.properties
+++ b/email-server/src/main/resources/i18n/messages_en.properties
@@ -1,3 +1,5 @@
+email.change-password.subject=Change password.
+
 email.recovery.subject=Reset password.
 
 email.verification.welcome=Welcome to

--- a/email-server/src/main/resources/templates/change-password-template.html
+++ b/email-server/src/main/resources/templates/change-password-template.html
@@ -1,0 +1,8 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+    <title>Change password</title>
+</head>
+<body>
+    <h1 th:text="${recoveryToken}"></h1>
+</body>
+</html>

--- a/email-server/src/test/java/com/traklibrary/email/server/controller/EmailControllerTest.java
+++ b/email-server/src/test/java/com/traklibrary/email/server/controller/EmailControllerTest.java
@@ -86,4 +86,34 @@ class EmailControllerTest {
         resultActions
                 .andExpect(MockMvcResultMatchers.status().isNoContent());
     }
+
+    @Test
+    void sendChangePasswordEmail_withMissingParameters_returns400() throws Exception {
+        // Act
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.put("/change-password")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept("application/vnd.traklibrary.v1.0+json"));
+
+        // Assert
+        resultActions
+                .andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+
+    @Test
+    void sendChangePasswordEmail_withParameters_returns200AndValidResponse() throws Exception {
+        // Arrange
+        Mockito.doNothing().when(emailService)
+                .sendChangePasswordEmail(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
+
+        // Act
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.put("/change-password")
+                .param("email-address", "test@traklibrary.com")
+                .param("recovery-token", "1234A")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept("application/vnd.traklibrary.v1.0+json"));
+
+        // Assert
+        resultActions
+                .andExpect(MockMvcResultMatchers.status().isNoContent());
+    }
 }

--- a/email-service/src/main/java/com/traklibrary/email/service/EmailService.java
+++ b/email-service/src/main/java/com/traklibrary/email/service/EmailService.java
@@ -44,4 +44,18 @@ public interface EmailService {
      * @param recoveryToken The randomly generated recovery token to attach to the email.
      */
     void sendRecoveryEmail(String emailAddress, String recoveryToken);
+
+    /**
+     * Given an email address and a password, this method will dispatch a change password email
+     * to the specified address using the email provider defined within the {@link EmailService}
+     * implementation. If any errors occur when dispatching an email, an {@link EmailFailedException}
+     * will be thrown and the information will be returned to the API callee.
+     *
+     * It should be noted, that no validation needs to occur with any {@link EmailService}
+     * implementation, validation of the fields should occur at the controller level.
+     *
+     * @param emailAddress The email address to send the change password email to.
+     * @param recoveryToken The randomly generated recovery token to attach to the email.
+     */
+    void sendChangePasswordEmail(String emailAddress, String recoveryToken);
 }

--- a/email-service/src/main/java/com/traklibrary/email/service/impl/EmailServiceThymeleafImpl.java
+++ b/email-service/src/main/java/com/traklibrary/email/service/impl/EmailServiceThymeleafImpl.java
@@ -26,6 +26,7 @@ public class EmailServiceThymeleafImpl implements EmailService {
 
     private static final String VERIFICATION_SUBJECT = "email.verification.subject";
     private static final String RECOVERY_SUBJECT = "email.recovery.subject";
+    private static final String CHANGE_PASSWORD_SUBJECT = "email.change-password.subject";
 
     @Setter
     @Value("${trak.aws.simple-email-service.from-address}")
@@ -65,6 +66,22 @@ public class EmailServiceThymeleafImpl implements EmailService {
             javaMailSender.send(getMimeMessage(emailDto, "recovery-template"));
         } catch (Exception e) {
             throw new EmailFailedException("Failed to send recovery email.", e);
+        }
+    }
+
+    @Override
+    public void sendChangePasswordEmail(String emailAddress, String recoveryToken) {
+        // Create the Email template and all the data it needs before sending.
+        EmailDto emailDto = new EmailDto();
+        emailDto.setFrom(fromAddress);
+        emailDto.setTo(emailAddress);
+        emailDto.setSubject(messageSource.getMessage(CHANGE_PASSWORD_SUBJECT, new Object[] {}, LocaleContextHolder.getLocale()));
+        emailDto.setData(Collections.singletonMap("recoveryToken", recoveryToken));
+
+        try {
+            javaMailSender.send(getMimeMessage(emailDto, "change-password-template"));
+        } catch (Exception e) {
+            throw new EmailFailedException("Failed to send change password email.", e);
         }
     }
 

--- a/email-service/src/test/java/com/traklibrary/email/service/impl/EmailServiceThymeleafImplTest.java
+++ b/email-service/src/test/java/com/traklibrary/email/service/impl/EmailServiceThymeleafImplTest.java
@@ -116,4 +116,47 @@ class EmailServiceThymeleafImplTest {
         Mockito.verify(javaMailSender, Mockito.atMostOnce())
                 .send(ArgumentMatchers.any(MimeMessage.class));
     }
+
+    @Test
+    void sendChangePasswordEmail_withFailingToSend_throwsEmailFailedException() {
+        // Arrange
+        emailService.setFromAddress("from@traklibrary.com");
+
+        Mockito.when(messageSource.getMessage(ArgumentMatchers.anyString(), ArgumentMatchers.any(Object[].class), ArgumentMatchers.any(Locale.class)))
+                .thenReturn("");
+
+        Mockito.when(javaMailSender.createMimeMessage())
+                .thenReturn(Mockito.mock(MimeMessage.class));
+
+        Mockito.when(templateEngine.process(ArgumentMatchers.eq("change-password-template"), ArgumentMatchers.any(IContext.class)))
+                .thenReturn("");
+
+        // Assert
+        Assertions.assertThrows(EmailFailedException.class, () -> emailService.sendChangePasswordEmail("", ""));
+    }
+
+    @Test
+    void sendChangePasswordEmail_withNoIssues_sendsEmail() {
+        // Arrange
+        emailService.setFromAddress("from@traklibrary.com");
+
+        Mockito.when(messageSource.getMessage(ArgumentMatchers.anyString(), ArgumentMatchers.any(Object[].class), ArgumentMatchers.any(Locale.class)))
+                .thenReturn("");
+
+        Mockito.when(javaMailSender.createMimeMessage())
+                .thenReturn(Mockito.mock(MimeMessage.class));
+
+        Mockito.when(templateEngine.process(ArgumentMatchers.eq("change-password-template"), ArgumentMatchers.any(IContext.class)))
+                .thenReturn("");
+
+        Mockito.doNothing()
+                .when(javaMailSender).send(ArgumentMatchers.any(MimeMessage.class));
+
+        // Act
+        emailService.sendChangePasswordEmail("email.address@test.com", "12345");
+
+        // Assert
+        Mockito.verify(javaMailSender, Mockito.atMostOnce())
+                .send(ArgumentMatchers.any(MimeMessage.class));
+    }
 }


### PR DESCRIPTION
- Added two new user service and controller methods, once for requesting a change password email be sent, and the other to change the users password, but only once they've supplied a valid recovery token.
- Added unit tests for the new user methods.
- Added a new endpoint and method to the email service, to allow for a change password email and template to be sent.
- Added tests for the new email endpoint and method.
- Increased the resilience timeout for sending emails.