### PR TITLE
API-3: Dockerise the different services.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ buildNumber.properties
 .mvn/timing.properties
 .mvn/wrapper/maven-wrapper.jar
 .flattened-pom.xml
+
+### Custom ###
+*.env

--- a/auth-domain/pom.xml
+++ b/auth-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>trak-api</artifactId>
         <groupId>com.traklibrary</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -41,14 +41,5 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/auth-domain/src/test/resources/logback-test.xml
+++ b/auth-domain/src/test/resources/logback-test.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration />

--- a/auth-repository/pom.xml
+++ b/auth-repository/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>trak-api</artifactId>
         <groupId>com.traklibrary</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,17 +22,8 @@
         <dependency>
             <groupId>com.traklibrary.authentication</groupId>
             <artifactId>auth-domain</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/auth-repository/src/test/resources/logback-test.xml
+++ b/auth-repository/src/test/resources/logback-test.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration />

--- a/auth-server/Dockerfile
+++ b/auth-server/Dockerfile
@@ -1,0 +1,20 @@
+FROM fabric8/java-alpine-openjdk8-jdk
+
+LABEL maintainer="Sparky Studios <benjamin.carter.dev@gmail.com>"
+
+WORKDIR app
+
+# Copy the jar file into the docker container.
+ARG jar=target/*.jar
+COPY ${jar} auth-server.jar
+
+# Additional debug arguments provided by the maven build.
+ARG DEBUG_ARGS
+ENV ENV_DEBUG=${DEBUG_ARGS}
+
+# Expose this port for external communication.
+EXPOSE 8080
+# Exposed for debug purposes.
+EXPOSE 5005
+
+ENTRYPOINT java ${ENV_DEBUG} -Djava.security.egd-file=file:/dev/./urandom -Xmx256m -jar auth-server.jar

--- a/auth-server/pom.xml
+++ b/auth-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>trak-api</artifactId>
         <groupId>com.traklibrary</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -38,19 +38,20 @@
         <dependency>
             <groupId>com.traklibrary.authentication</groupId>
             <artifactId>auth-service</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 
     <build>
+        <finalName>traklibrary-auth-server</finalName>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/auth-server/src/main/resources/bootstrap.yml
+++ b/auth-server/src/main/resources/bootstrap.yml
@@ -1,3 +1,8 @@
+eureka:
+  client:
+    service-url:
+      defaultZone: http://discovery-server:8761/eureka
+
 spring:
   application:
     name: trak-auth-server
@@ -7,5 +12,3 @@ spring:
         enabled: true
         service-id: trak-config-server
       enabled: true
-  profiles:
-    active: development

--- a/auth-server/src/test/resources/logback-test.xml
+++ b/auth-server/src/test/resources/logback-test.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration />

--- a/auth-service/pom.xml
+++ b/auth-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>trak-api</artifactId>
         <groupId>com.traklibrary</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -56,17 +56,8 @@
         <dependency>
             <groupId>com.traklibrary.authentication</groupId>
             <artifactId>auth-repository</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/buildspec-development.yml
+++ b/buildspec-development.yml
@@ -31,17 +31,3 @@ phases:
         then
           mvn verify sonar:sonar -Pcoverage -Dsonar.branch.name=develop
         fi
-      - echo [INFO] Packaging Trak API `date`
-      - mvn package -DskipTests
-
-artifacts:
-  files:
-    - auth-server/target/auth-server-1.0-SNAPSHOT.jar
-    - config-server/target/config-server-1.0-SNAPSHOT.jar
-    - discovery-server/target/discovery-server-1.0-SNAPSHOT.jar
-    - email-server/target/email-server-1.0-SNAPSHOT.jar
-    - game-server/target/game-server-1.0-SNAPSHOT.jar
-    - gateway-server/target/gateway-server-1.0-SNAPSHOT.jar
-    - image-server/target/image-server-1.0-SNAPSHOT.jar
-    - notification-server/target/notification-server-1.0-SNAPSHOT.jar
-  discard-paths: yes

--- a/config-server/Dockerfile
+++ b/config-server/Dockerfile
@@ -1,0 +1,20 @@
+FROM fabric8/java-alpine-openjdk8-jdk
+
+LABEL maintainer="Sparky Studios <benjamin.carter.dev@gmail.com>"
+
+WORKDIR app
+
+# Copy the jar file into the docker container.
+ARG jar=target/*.jar
+COPY ${jar} config-server.jar
+
+# Additional debug arguments provided by the maven build.
+ARG DEBUG_ARGS
+ENV ENV_DEBUG=${DEBUG_ARGS}
+
+# Expose this port for external communication.
+EXPOSE 8080
+# Exposed for debug purposes.
+EXPOSE 5005
+
+ENTRYPOINT java ${ENV_DEBUG} -Djava.security.egd-file=file:/dev/./urandom -Xmx256m -jar config-server.jar

--- a/config-server/pom.xml
+++ b/config-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>trak-api</artifactId>
         <groupId>com.traklibrary</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -41,10 +41,15 @@
     </dependencies>
 
     <build>
+        <finalName>traklibrary-config-server</finalName>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/config-server/src/main/resources/application.yml
+++ b/config-server/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 eureka:
   client:
     service-url:
-      defaultZone: ${EUREKA_SERVER:http://localhost:8761/eureka}
+      defaultZone: http://discovery-server:8761/eureka
 
 spring:
   application:
@@ -11,8 +11,6 @@ spring:
       server:
         git:
           uri: https://github.com/TheLordBritish/trak-api-properties.git
-  profiles:
-    active: development
 
 server:
   port: 8888

--- a/discovery-server/Dockerfile
+++ b/discovery-server/Dockerfile
@@ -1,0 +1,20 @@
+FROM fabric8/java-alpine-openjdk8-jdk
+
+LABEL maintainer="Sparky Studios <benjamin.carter.dev@gmail.com>"
+
+WORKDIR app
+
+# Copy the jar file into the docker container.
+ARG jar=target/*.jar
+COPY ${jar} discovery-server.jar
+
+# Additional debug arguments provided by the maven build.
+ARG DEBUG_ARGS
+ENV ENV_DEBUG=${DEBUG_ARGS}
+
+# Expose this port for external communication.
+EXPOSE 8080
+# Exposed for debug purposes.
+EXPOSE 5005
+
+ENTRYPOINT java ${ENV_DEBUG} -Djava.security.egd-file=file:/dev/./urandom -Xmx256m -jar discovery-server.jar

--- a/discovery-server/pom.xml
+++ b/discovery-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>trak-api</artifactId>
         <groupId>com.traklibrary</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -25,10 +25,15 @@
     </dependencies>
 
     <build>
+        <finalName>traklibrary-discovery-server</finalName>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/discovery-server/src/main/resources/application.yml
+++ b/discovery-server/src/main/resources/application.yml
@@ -7,5 +7,3 @@ eureka:
 spring:
   application:
     name: trak-discovery-server
-  profiles:
-    active: development

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,0 +1,104 @@
+version: '3.3'
+services:
+  db:
+    container_name: traklibrary-db
+    image: postgres:9.6
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=postgres
+    volumes:
+      - trak-db-data:/var/lib/postgresql/data
+      - ./scripts/db:/docker-entrypoint-initdb.d
+    ports:
+      - 5433:5432
+    networks:
+      - trak-network
+
+  auth-server:
+    volumes:
+      - ./logs:/app/logs
+    command: ["-m", "512m"]
+    environment:
+      - spring.profiles.active=development
+    depends_on:
+      - db
+      - discovery-server
+      - config-server
+    ports:
+      - 8081:8080
+      - 5005:5005
+
+  config-server:
+    volumes:
+      - ./logs:/app/logs
+    environment:
+      - spring.profiles.active=development
+    ports:
+      - 8888:8888
+      - 5006:5005
+
+  discovery-server:
+    volumes:
+      - ./logs:/app/logs
+    environment:
+      - spring.profiles.active=development
+    ports:
+      - 8761:8761
+      - 5007:5005
+
+  email-server:
+    volumes:
+      - ./logs:/app/logs
+    environment:
+      - spring.profiles.active=development
+    ports:
+      - 8082:8080
+      - 5008:5005
+
+  game-server:
+    volumes:
+      - ./logs:/app/logs
+    environment:
+      - spring.profiles.active=development
+    depends_on:
+      - db
+      - discovery-server
+      - config-server
+    ports:
+      - 8083:8080
+      - 5009:5005
+
+  gateway-server:
+    volumes:
+      - ./logs:/app/logs
+    environment:
+      - spring.profiles.active=development
+    ports:
+      - 8080:8080
+      - 5010:5005
+
+  image-server:
+    volumes:
+      - ./logs:/app/logs
+    environment:
+      - spring.profiles.active=development
+    ports:
+      - 8084:8080
+      - 5011:5005
+
+  notification-server:
+    volumes:
+      - ./logs:/app/logs
+    environment:
+      - spring.profiles.active=development
+    depends_on:
+      - db
+      - discovery-server
+      - config-server
+    ports:
+      - 8085:8080
+      - 5012:5005
+
+volumes:
+  trak-db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,120 @@
+version: "3.3"
+services:
+  auth-server:
+    build:
+      context: ./auth-server
+    container_name: traklibrary-auth-server
+    image: sparkystudios/traklibrary-auth-server:latest
+    command: ["-m", "512m"]
+    environment:
+      - spring.cloud.config.username=${CONFIG_SERVER_SECURITY_USERNAME}
+      - spring.cloud.config.password=${CONFIG_SERVER_SECURITY_PASSWORD}
+    depends_on:
+      - discovery-server
+      - config-server
+    networks:
+      - trak-network
+
+  config-server:
+    build:
+      context: ./config-server
+    container_name: traklibrary-config-server
+    image: sparkystudios/traklibrary-config-server:latest
+    command: ["-m", "512m"]
+    environment:
+      - spring.cloud.config.server.git.password=${CONFIG_SERVER_GIT_PASSWORD}
+      - spring.cloud.config.server.git.username=${CONFIG_SERVER_GIT_USERNAME}
+      - spring.security.user.name=${CONFIG_SERVER_SECURITY_USERNAME}
+      - spring.security.user.password=${CONFIG_SERVER_SECURITY_PASSWORD}
+    depends_on:
+      - discovery-server
+    networks:
+      - trak-network
+
+  discovery-server:
+    build:
+      context: ./discovery-server
+    container_name: traklibrary-discovery-server
+    image: sparkystudios/traklibrary-discovery-server:latest
+    command: ["-m", "512m"]
+    networks:
+      - trak-network
+
+  email-server:
+    build:
+      context: ./email-server
+    container_name: traklibrary-email-server
+    image: sparkystudios/traklibrary-email-server:latest
+    command: ["-m", "512m"]
+    environment:
+      - spring.cloud.config.username=${CONFIG_SERVER_SECURITY_USERNAME}
+      - spring.cloud.config.password=${CONFIG_SERVER_SECURITY_PASSWORD}
+    depends_on:
+      - discovery-server
+      - config-server
+    networks:
+      - trak-network
+
+  game-server:
+    build:
+      context: ./game-server
+    container_name: traklibrary-game-server
+    image: sparkystudios/traklibrary-game-server:latest
+    command: ["-m", "512m"]
+    environment:
+      - spring.cloud.config.username=${CONFIG_SERVER_SECURITY_USERNAME}
+      - spring.cloud.config.password=${CONFIG_SERVER_SECURITY_PASSWORD}
+    depends_on:
+      - discovery-server
+      - config-server
+    networks:
+      - trak-network
+
+  gateway-server:
+    build:
+      context: ./gateway-server
+    container_name: traklibrary-gateway-server
+    image: sparkystudios/traklibrary-gateway-server:latest
+    command: ["-m", "512m"]
+    environment:
+      - spring.cloud.config.username=${CONFIG_SERVER_SECURITY_USERNAME}
+      - spring.cloud.config.password=${CONFIG_SERVER_SECURITY_PASSWORD}
+    depends_on:
+      - discovery-server
+      - config-server
+    networks:
+      - trak-network
+
+  image-server:
+    build:
+      context: ./image-server
+    container_name: traklibrary-image-server
+    image: sparkystudios/traklibrary-image-server:latest
+    command: ["-m", "512m"]
+    environment:
+      - spring.cloud.config.username=${CONFIG_SERVER_SECURITY_USERNAME}
+      - spring.cloud.config.password=${CONFIG_SERVER_SECURITY_PASSWORD}
+    depends_on:
+      - discovery-server
+      - config-server
+    networks:
+      - trak-network
+
+  notification-server:
+    build:
+      context: ./notification-server
+    container_name: traklibrary-notification-server
+    image: sparkystudios/traklibrary-notification-server:latest
+    command: ["-m", "512m"]
+    environment:
+      - spring.cloud.config.username=${CONFIG_SERVER_SECURITY_USERNAME}
+      - spring.cloud.config.password=${CONFIG_SERVER_SECURITY_PASSWORD}
+    depends_on:
+      - discovery-server
+      - config-server
+    networks:
+      - trak-network
+
+networks:
+  trak-network:
+    driver: bridge

--- a/email-server/Dockerfile
+++ b/email-server/Dockerfile
@@ -1,0 +1,20 @@
+FROM fabric8/java-alpine-openjdk8-jdk
+
+LABEL maintainer="Sparky Studios <benjamin.carter.dev@gmail.com>"
+
+WORKDIR app
+
+# Copy the jar file into the docker container.
+ARG jar=target/*.jar
+COPY ${jar} email-server.jar
+
+# Additional debug arguments provided by the maven build.
+ARG DEBUG_ARGS
+ENV ENV_DEBUG=${DEBUG_ARGS}
+
+# Expose this port for external communication.
+EXPOSE 8080
+# Exposed for debug purposes.
+EXPOSE 5005
+
+ENTRYPOINT java ${ENV_DEBUG} -Djava.security.egd-file=file:/dev/./urandom -Xmx256m -jar email-server.jar

--- a/email-server/pom.xml
+++ b/email-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>trak-api</artifactId>
         <groupId>com.traklibrary</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -42,19 +42,20 @@
         <dependency>
             <groupId>com.traklibrary.email</groupId>
             <artifactId>email-service</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 
     <build>
+        <finalName>traklibrary-email-server</finalName>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/email-server/src/main/resources/bootstrap.yml
+++ b/email-server/src/main/resources/bootstrap.yml
@@ -1,3 +1,8 @@
+eureka:
+  client:
+    service-url:
+      defaultZone: http://discovery-server:8761/eureka
+
 spring:
   application:
     name: trak-email-server
@@ -7,5 +12,3 @@ spring:
         enabled: true
         service-id: trak-config-server
       enabled: true
-  profiles:
-    active: development

--- a/email-server/src/test/resources/logback-test.xml
+++ b/email-server/src/test/resources/logback-test.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration />

--- a/email-service/pom.xml
+++ b/email-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>trak-api</artifactId>
         <groupId>com.traklibrary</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -43,14 +43,5 @@
             <artifactId>spring-cloud-starter-aws</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/game-domain/pom.xml
+++ b/game-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>trak-api</artifactId>
         <groupId>com.traklibrary</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -38,12 +38,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/game-domain/src/test/resources/logback-test.xml
+++ b/game-domain/src/test/resources/logback-test.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration />

--- a/game-repository/pom.xml
+++ b/game-repository/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>trak-api</artifactId>
         <groupId>com.traklibrary</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -26,16 +26,8 @@
         <dependency>
             <groupId>com.traklibrary.game</groupId>
             <artifactId>game-domain</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/game-repository/src/test/resources/logback-test.xml
+++ b/game-repository/src/test/resources/logback-test.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration />

--- a/game-server/Dockerfile
+++ b/game-server/Dockerfile
@@ -1,0 +1,20 @@
+FROM fabric8/java-alpine-openjdk8-jdk
+
+LABEL maintainer="Sparky Studios <benjamin.carter.dev@gmail.com>"
+
+WORKDIR app
+
+# Copy the jar file into the docker container.
+ARG jar=target/*.jar
+COPY ${jar} game-server.jar
+
+# Additional debug arguments provided by the maven build.
+ARG DEBUG_ARGS
+ENV ENV_DEBUG=${DEBUG_ARGS}
+
+# Expose this port for external communication.
+EXPOSE 8080
+# Exposed for debug purposes.
+EXPOSE 5005
+
+ENTRYPOINT java ${ENV_DEBUG} -Djava.security.egd-file=file:/dev/./urandom -Xmx256m -jar game-server.jar

--- a/game-server/pom.xml
+++ b/game-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>trak-api</artifactId>
         <groupId>com.traklibrary</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -55,19 +55,20 @@
         <dependency>
             <groupId>com.traklibrary.game</groupId>
             <artifactId>game-service</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 
     <build>
+        <finalName>traklibrary-game-server</finalName>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/game-server/src/main/resources/bootstrap.yml
+++ b/game-server/src/main/resources/bootstrap.yml
@@ -1,3 +1,8 @@
+eureka:
+  client:
+    service-url:
+      defaultZone: http://discovery-server:8761/eureka
+
 spring:
   application:
     name: trak-game-server
@@ -7,5 +12,3 @@ spring:
         enabled: true
         service-id: trak-config-server
       enabled: true
-  profiles:
-    active: development

--- a/game-server/src/test/resources/logback-test.xml
+++ b/game-server/src/test/resources/logback-test.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration />

--- a/game-service/pom.xml
+++ b/game-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>trak-api</artifactId>
         <groupId>com.traklibrary</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -51,16 +51,8 @@
         <dependency>
             <groupId>com.traklibrary.game</groupId>
             <artifactId>game-repository</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/gateway-server/Dockerfile
+++ b/gateway-server/Dockerfile
@@ -1,0 +1,20 @@
+FROM fabric8/java-alpine-openjdk8-jdk
+
+LABEL maintainer="Sparky Studios <benjamin.carter.dev@gmail.com>"
+
+WORKDIR app
+
+# Copy the jar file into the docker container.
+ARG jar=target/*.jar
+COPY ${jar} gateway-server.jar
+
+# Additional debug arguments provided by the maven build.
+ARG DEBUG_ARGS
+ENV ENV_DEBUG=${DEBUG_ARGS}
+
+# Expose this port for external communication.
+EXPOSE 8080
+# Exposed for debug purposes.
+EXPOSE 5005
+
+ENTRYPOINT java ${ENV_DEBUG} -Djava.security.egd-file=file:/dev/./urandom -Xmx256m -jar gateway-server.jar

--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>trak-api</artifactId>
         <groupId>com.traklibrary</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -14,6 +14,7 @@
     <name>Trak API Gateway Server</name>
 
     <properties>
+        <jar>${project.build.directory}/${project.build.finalName}.jar</jar>
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
@@ -45,10 +46,15 @@
     </dependencies>
 
     <build>
+        <finalName>traklibrary-gateway-server</finalName>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/gateway-server/src/main/resources/bootstrap.yml
+++ b/gateway-server/src/main/resources/bootstrap.yml
@@ -1,3 +1,8 @@
+eureka:
+  client:
+    service-url:
+      defaultZone: http://discovery-server:8761/eureka
+
 spring:
   application:
     name: trak-gateway-server
@@ -7,5 +12,3 @@ spring:
         enabled: true
         service-id: trak-config-server
       enabled: true
-  profiles:
-    active: development

--- a/image-server/Dockerfile
+++ b/image-server/Dockerfile
@@ -1,0 +1,20 @@
+FROM fabric8/java-alpine-openjdk8-jdk
+
+LABEL maintainer="Sparky Studios <benjamin.carter.dev@gmail.com>"
+
+WORKDIR app
+
+# Copy the jar file into the docker container.
+ARG jar=target/*.jar
+COPY ${jar} image-server.jar
+
+# Additional debug arguments provided by the maven build.
+ARG DEBUG_ARGS
+ENV ENV_DEBUG=${DEBUG_ARGS}
+
+# Expose this port for external communication.
+EXPOSE 8080
+# Exposed for debug purposes.
+EXPOSE 5005
+
+ENTRYPOINT java ${ENV_DEBUG} -Djava.security.egd-file=file:/dev/./urandom -Xmx256m -jar image-server.jar

--- a/image-server/pom.xml
+++ b/image-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>trak-api</artifactId>
         <groupId>com.traklibrary</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -42,19 +42,20 @@
         <dependency>
             <groupId>com.traklibrary.image</groupId>
             <artifactId>image-service</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 
     <build>
+        <finalName>traklibrary-image-server</finalName>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/image-server/src/main/resources/bootstrap.yml
+++ b/image-server/src/main/resources/bootstrap.yml
@@ -1,3 +1,8 @@
+eureka:
+  client:
+    service-url:
+      defaultZone: http://discovery-server:8761/eureka
+
 spring:
   application:
     name: trak-image-server
@@ -7,5 +12,3 @@ spring:
         enabled: true
         service-id: trak-config-server
       enabled: true
-  profiles:
-    active: development

--- a/image-server/src/test/resources/logback-test.xml
+++ b/image-server/src/test/resources/logback-test.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration />

--- a/image-service/pom.xml
+++ b/image-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>trak-api</artifactId>
         <groupId>com.traklibrary</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -27,14 +27,5 @@
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/notification-domain/pom.xml
+++ b/notification-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>trak-api</artifactId>
         <groupId>com.traklibrary</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -37,14 +37,5 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/notification-domain/src/test/resources/logback-test.xml
+++ b/notification-domain/src/test/resources/logback-test.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration />

--- a/notification-repository/pom.xml
+++ b/notification-repository/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>trak-api</artifactId>
         <groupId>com.traklibrary</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,17 +22,8 @@
         <dependency>
             <groupId>com.traklibrary.notification</groupId>
             <artifactId>notification-domain</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/notification-repository/src/test/resources/logback-test.xml
+++ b/notification-repository/src/test/resources/logback-test.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration />

--- a/notification-server/Dockerfile
+++ b/notification-server/Dockerfile
@@ -1,0 +1,20 @@
+FROM fabric8/java-alpine-openjdk8-jdk
+
+LABEL maintainer="Sparky Studios <benjamin.carter.dev@gmail.com>"
+
+WORKDIR app
+
+# Copy the jar file into the docker container.
+ARG jar=target/*.jar
+COPY ${jar} notification-server.jar
+
+# Additional debug arguments provided by the maven build.
+ARG DEBUG_ARGS
+ENV ENV_DEBUG=${DEBUG_ARGS}
+
+# Expose this port for external communication.
+EXPOSE 8080
+# Exposed for debug purposes.
+EXPOSE 5005
+
+ENTRYPOINT java ${ENV_DEBUG} -Djava.security.egd-file=file:/dev/./urandom -Xmx256m -jar notification-server.jar

--- a/notification-server/pom.xml
+++ b/notification-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>trak-api</artifactId>
         <groupId>com.traklibrary</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -38,19 +38,20 @@
         <dependency>
             <groupId>com.traklibrary.notification</groupId>
             <artifactId>notification-service</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 
     <build>
+        <finalName>traklibrary-notification-server</finalName>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/notification-server/src/main/resources/bootstrap.yml
+++ b/notification-server/src/main/resources/bootstrap.yml
@@ -1,3 +1,8 @@
+eureka:
+  client:
+    service-url:
+      defaultZone: http://discovery-server:8761/eureka
+
 spring:
   application:
     name: trak-notification-server
@@ -7,5 +12,3 @@ spring:
         enabled: true
         service-id: trak-config-server
       enabled: true
-  profiles:
-    active: development

--- a/notification-server/src/test/resources/logback-test.xml
+++ b/notification-server/src/test/resources/logback-test.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration />

--- a/notification-service/pom.xml
+++ b/notification-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>trak-api</artifactId>
         <groupId>com.traklibrary</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -38,17 +38,8 @@
         <dependency>
             <groupId>com.traklibrary.notification</groupId>
             <artifactId>notification-repository</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.traklibrary</groupId>
     <artifactId>trak-api</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <name>Trak API</name>
     <packaging>pom</packaging>
 
@@ -23,6 +23,68 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-maven-plugin</artifactId>
+                            <configuration>
+                                <excludeDevtools>false</excludeDevtools>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>com.spotify</groupId>
+                            <artifactId>dockerfile-maven-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <id>default</id>
+                                    <phase>package</phase>
+                                    <goals>
+                                        <goal>build</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                            <configuration>
+                                <repository>sparkystudios/${project.build.finalName}</repository>
+                                <buildArgs>
+                                    <DEBUG_ARGS>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005</DEBUG_ARGS>
+                                </buildArgs>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>production</id>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-maven-plugin</artifactId>
+                        </plugin>
+                        <plugin>
+                            <groupId>com.spotify</groupId>
+                            <artifactId>dockerfile-maven-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <id>default</id>
+                                    <phase>package</phase>
+                                    <goals>
+                                        <goal>build</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                            <configuration>
+                                <repository>sparkystudios/${project.build.finalName}</repository>
+                                <tag>${project.version}</tag>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
         </profile>
         <profile>
             <id>coverage</id>
@@ -137,8 +199,6 @@
         <org.sonarsource.scanner.maven.version>3.7.0.1746</org.sonarsource.scanner.maven.version>
         <org.projectlombok.version>1.18.12</org.projectlombok.version>
         <org.springframework.cloud.version>Hoxton.SR3</org.springframework.cloud.version>
-        <!-- Plugin versions -->
-        <org.apache.maven.plugins.compiler.version>3.8.1</org.apache.maven.plugins.compiler.version>
         <!-- Used to specify parameters for sonarcloud analysis. -->
         <aggregate.report.dir>report-aggregator/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
     </properties>
@@ -277,28 +337,35 @@
     </dependencyManagement>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${org.mapstruct.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${org.projectlombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${org.apache.maven.plugins.compiler.version}</version>
-                    <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
-                        <annotationProcessorPaths>
-                            <path>
-                                <groupId>org.mapstruct</groupId>
-                                <artifactId>mapstruct-processor</artifactId>
-                                <version>${org.mapstruct.version}</version>
-                            </path>
-                            <path>
-                                <groupId>org.projectlombok</groupId>
-                                <artifactId>lombok</artifactId>
-                                <version>${org.projectlombok.version}</version>
-                            </path>
-                        </annotationProcessorPaths>
-                    </configuration>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${org.jacoco.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.sonarsource.scanner.maven</groupId>
@@ -306,9 +373,13 @@
                     <version>${org.sonarsource.scanner.maven.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.jacoco</groupId>
-                    <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>${org.jacoco.version}</version>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                </plugin>
+                <plugin>
+                    <groupId>com.spotify</groupId>
+                    <artifactId>dockerfile-maven-plugin</artifactId>
+                    <version>1.4.10</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/report-aggregator/pom.xml
+++ b/report-aggregator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>trak-api</artifactId>
         <groupId>com.traklibrary</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -17,97 +17,97 @@
         <dependency>
             <groupId>com.traklibrary.authentication</groupId>
             <artifactId>auth-domain</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.traklibrary.authentication</groupId>
             <artifactId>auth-repository</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.traklibrary.authentication</groupId>
             <artifactId>auth-server</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.traklibrary.authentication</groupId>
             <artifactId>auth-service</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.traklibrary.config</groupId>
             <artifactId>config-server</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.traklibrary.discovery</groupId>
             <artifactId>discovery-server</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.traklibrary.email</groupId>
             <artifactId>email-server</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.traklibrary.email</groupId>
             <artifactId>email-service</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.traklibrary.game</groupId>
             <artifactId>game-domain</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.traklibrary.game</groupId>
             <artifactId>game-repository</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.traklibrary.game</groupId>
             <artifactId>game-server</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.traklibrary.game</groupId>
             <artifactId>game-service</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.traklibrary.gateway</groupId>
             <artifactId>gateway-server</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.traklibrary.image</groupId>
             <artifactId>image-server</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.traklibrary.image</groupId>
             <artifactId>image-service</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.traklibrary.notification</groupId>
             <artifactId>notification-domain</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.traklibrary.notification</groupId>
             <artifactId>notification-repository</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.traklibrary.notification</groupId>
             <artifactId>notification-server</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.traklibrary.notification</groupId>
             <artifactId>notification-service</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/scripts/db/init.sh
+++ b/scripts/db/init.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --password "$POSTGRES_PASSWORD" --dbname "$POSTGRES_DB" <<-EOSQL
+
+  CREATE DATABASE authdb;
+  GRANT ALL PRIVILEGES ON DATABASE authdb TO postgres;
+
+  CREATE DATABASE gamedb;
+  GRANT ALL PRIVILEGES ON DATABASE gamedb TO postgres;
+
+  CREATE DATABASE notificationdb;
+  GRANT ALL PRIVILEGES ON DATABASE notificationdb TO postgres;
+EOSQL


### PR DESCRIPTION
- Simplified the submodule pom's and moved more configuration in profiles to the parent.
- Added a Dockerfile for each different microservice, which just executes the jar file created during the mavenbuild.
- Added plugin to create docker images in a development environment during the package stage.
- Added eureka config to the bootstrap files of the microservices, as it's needed once the images are started.
- Added a docker-compose file which can be used in conjunction with docker-compose.development to easily deploy images in a development environment.
- Remote debuggin is enabled for development images.
- At this time, the images are not pushed to DockerHub, this should only be done with a production build.
- Spring reloading is not enabled for the docker images at this time.
- Added logback-test files to reduce the amount of noise in the maven build.