### PR TITLE
API-24: Add support for franchises.

### DIFF
--- a/auth-server/pom.xml
+++ b/auth-server/pom.xml
@@ -59,8 +59,8 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/buildspec-staging.yml
+++ b/buildspec-staging.yml
@@ -33,4 +33,3 @@ phases:
         then
           mvn verify sonar:sonar -Pstaging -Dsonar.branch.name=staging
         fi
-      - mvn dockerfile:push -Ddockerfile.username=$DOCKER_USERNAME -Ddockerfile.password=$DOCKER_PASSWORD

--- a/config-server/pom.xml
+++ b/config-server/pom.xml
@@ -48,8 +48,8 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/discovery-server/pom.xml
+++ b/discovery-server/pom.xml
@@ -32,8 +32,8 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/email-server/pom.xml
+++ b/email-server/pom.xml
@@ -50,8 +50,8 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/Franchise.java
+++ b/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/Franchise.java
@@ -1,0 +1,47 @@
+package com.sparkystudios.traklibrary.game.domain;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Data
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "franchise")
+public class Franchise {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", unique = true, nullable = false, updatable = false)
+    private long id;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "description", length = 4096)
+    private String description;
+
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    @OneToMany(mappedBy = "franchise", fetch = FetchType.LAZY)
+    private Collection<Game> games = new ArrayList<>();
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Version
+    @Column(name = "op_lock_version")
+    private Long version;
+}

--- a/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/Game.java
+++ b/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/Game.java
@@ -1,9 +1,7 @@
 package com.sparkystudios.traklibrary.game.domain;
 
 import com.sparkystudios.traklibrary.game.domain.converter.GameModeAttributeConverter;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -83,6 +81,15 @@ public class Game {
     @Convert(converter = GameModeAttributeConverter.class)
     @Column(name = "game_modes", nullable = false)
     private Set<GameMode> gameModes = EnumSet.noneOf(GameMode.class);
+
+    @Column(name = "franchise_id")
+    private Long franchiseId;
+
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "franchise_id", insertable = false, updatable = false)
+    private Franchise franchise;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreatedDate

--- a/game-domain/src/main/resources/db/changelog/001-initial.xml
+++ b/game-domain/src/main/resources/db/changelog/001-initial.xml
@@ -25,6 +25,7 @@
             <column name="game_modes" type="bigint" defaultValueNumeric="0">
                 <constraints nullable="false"/>
             </column>
+            <column name="franchise_id" type="bigint" />
             <column name="created_at" type="TIMESTAMP WITHOUT TIME ZONE" defaultValueComputed="CURRENT_TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
@@ -449,7 +450,31 @@
                 columnNames="platform_id,region"
                 constraintName="unq_platform_release_date_platform_id_region" />
 
+        <createTable tableName="franchise">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false" primaryKeyName="pk_franchise" />
+            </column>
+            <column name="title" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="varchar(4096)"/>
+            <column name="created_at" type="TIMESTAMP WITHOUT TIME ZONE" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP WITHOUT TIME ZONE" defaultValueComputed="CURRENT_TIMESTAMP"/>
+            <column name="op_lock_version" type="bigint" defaultValueNumeric="0"/>
+        </createTable>
+
+        <!-- game foreign key constraints -->
+        <addForeignKeyConstraint
+                baseTableName="game"
+                baseColumnNames="franchise_id"
+                constraintName="fk_game_franchise_id"
+                referencedTableName="franchise"
+                referencedColumnNames="id" />
+
         <rollback>
+            <dropTable tableName="franchise" />
             <dropTable tableName="platform_release_date" />
             <dropTable tableName="game_release_date" />
             <dropTable tableName="game_barcode" />

--- a/game-domain/src/test/java/com/sparkystudios/traklibrary/game/domain/FranchiseTest.java
+++ b/game-domain/src/test/java/com/sparkystudios/traklibrary/game/domain/FranchiseTest.java
@@ -73,7 +73,7 @@ class FranchiseTest {
         Franchise result = testEntityManager.persistFlushFind(franchise);
 
         // Assert
-        Assertions.assertThat(result.getGames().size()).isEqualTo(2);
+        Assertions.assertThat(result.getGames()).hasSize(2);
         Assertions.assertThat(result.getGames().stream().map(Game::getId).collect(Collectors.toList()))
                 .isEqualTo(List.of(game1.getId(), game2.getId()));
     }

--- a/game-domain/src/test/java/com/sparkystudios/traklibrary/game/domain/FranchiseTest.java
+++ b/game-domain/src/test/java/com/sparkystudios/traklibrary/game/domain/FranchiseTest.java
@@ -1,0 +1,80 @@
+package com.sparkystudios.traklibrary.game.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import javax.persistence.PersistenceException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@DataJpaTest
+class FranchiseTest {
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    @Test
+    void persist_withNullTitle_throwsPersistenceException() {
+        // Arrange
+        Franchise franchise = new Franchise();
+        franchise.setTitle(null);
+        franchise.setDescription("test-description");
+
+        // Assert
+        Assertions.assertThatExceptionOfType(PersistenceException.class)
+                .isThrownBy(() -> testEntityManager.persistFlushFind(franchise));
+    }
+
+    @Test
+    void persist_withValidFranchise_mapsFranchise() {
+        // Arrange
+        Franchise franchise = new Franchise();
+        franchise.setTitle("test-title");
+        franchise.setDescription("test-description");
+
+        // Act
+        Franchise result = testEntityManager.persistFlushFind(franchise);
+
+        // Assert
+        Assertions.assertThat(result.getId()).isGreaterThan(0L);
+        Assertions.assertThat(result.getTitle()).isEqualTo(franchise.getTitle());
+        Assertions.assertThat(result.getDescription()).isEqualTo(franchise.getDescription());
+        Assertions.assertThat(result.getCreatedAt()).isNotNull();
+        Assertions.assertThat(result.getUpdatedAt()).isNotNull();
+        Assertions.assertThat(result.getVersion()).isNotNull().isGreaterThanOrEqualTo(0L);
+    }
+
+    @Test
+    void persist_withValidGameRelationships_mapsRelationships() {
+        // Arrange
+        Franchise franchise = new Franchise();
+        franchise.setTitle("test-title");
+        franchise.setDescription("test-description");
+        franchise = testEntityManager.persistFlushFind(franchise);
+
+        Game game1 = new Game();
+        game1.setTitle("game-title-1");
+        game1.setDescription("game-description-1");
+        game1.setAgeRating(AgeRating.EVERYONE_TEN_PLUS);
+        game1.setFranchiseId(franchise.getId());
+        game1 = testEntityManager.persistFlushFind(game1);
+
+        Game game2 = new Game();
+        game2.setTitle("game-title-2");
+        game2.setDescription("game-description-2");
+        game2.setAgeRating(AgeRating.ADULTS_ONLY);
+        game2.setFranchiseId(franchise.getId());
+        game2 = testEntityManager.persistFlushFind(game2);
+
+        // Act
+        Franchise result = testEntityManager.persistFlushFind(franchise);
+
+        // Assert
+        Assertions.assertThat(result.getGames().size()).isEqualTo(2);
+        Assertions.assertThat(result.getGames().stream().map(Game::getId).collect(Collectors.toList()))
+                .isEqualTo(List.of(game1.getId(), game2.getId()));
+    }
+}

--- a/game-domain/src/test/java/com/sparkystudios/traklibrary/game/domain/GameTest.java
+++ b/game-domain/src/test/java/com/sparkystudios/traklibrary/game/domain/GameTest.java
@@ -410,4 +410,26 @@ class GameTest {
         Assertions.assertThat(result.getReleaseDates().iterator().next().getId())
                 .isEqualTo(gameReleaseDate3.getId());
     }
+
+    @Test
+    void persist_withValidFranchiseRelationship_mapsRelationship() {
+        // Arrange
+        Franchise franchise = new Franchise();
+        franchise.setTitle("test-franchise");
+        franchise.setDescription("test-franchise-description");
+        franchise = testEntityManager.persistFlushFind(franchise);
+
+        Game game = new Game();
+        game.setTitle("game-title-1");
+        game.setDescription("game-description-1");
+        game.setAgeRating(AgeRating.EVERYONE_TEN_PLUS);
+        game.setFranchiseId(franchise.getId());
+
+        // Act
+        Game result = testEntityManager.persistFlushFind(game);
+
+        // Assert
+        Assertions.assertThat(result.getFranchise()).isEqualTo(franchise);
+        Assertions.assertThat(result.getFranchiseId()).isEqualTo(franchise.getId());
+    }
 }

--- a/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/FranchiseRepository.java
+++ b/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/FranchiseRepository.java
@@ -1,0 +1,10 @@
+package com.sparkystudios.traklibrary.game.repository;
+
+import com.sparkystudios.traklibrary.game.domain.Franchise;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FranchiseRepository extends PagingAndSortingRepository<Franchise, Long>, JpaSpecificationExecutor<Franchise> {
+}

--- a/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/GameRepository.java
+++ b/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/GameRepository.java
@@ -14,6 +14,10 @@ public interface GameRepository extends PagingAndSortingRepository<Game, Long>, 
 
     long countByDevelopersId(long developerId);
 
+    Page<Game> findByFranchiseId(long franchise, Pageable pageable);
+
+    long countByFranchiseId(long franchiseId);
+
     Page<Game> findByPublishersId(long publisherId, Pageable pageable);
 
     long countByPublishersId(long publisherId);

--- a/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/DeveloperSpecification.java
+++ b/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/DeveloperSpecification.java
@@ -2,7 +2,6 @@ package com.sparkystudios.traklibrary.game.repository.specification;
 
 import com.sparkystudios.traklibrary.game.domain.Developer;
 import net.kaczmarzyk.spring.data.jpa.domain.Equal;
-import net.kaczmarzyk.spring.data.jpa.domain.Like;
 import net.kaczmarzyk.spring.data.jpa.domain.StartingWithIgnoreCase;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.And;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;

--- a/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/DeveloperSpecification.java
+++ b/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/DeveloperSpecification.java
@@ -3,13 +3,14 @@ package com.sparkystudios.traklibrary.game.repository.specification;
 import com.sparkystudios.traklibrary.game.domain.Developer;
 import net.kaczmarzyk.spring.data.jpa.domain.Equal;
 import net.kaczmarzyk.spring.data.jpa.domain.Like;
+import net.kaczmarzyk.spring.data.jpa.domain.StartingWithIgnoreCase;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.And;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
 import org.springframework.data.jpa.domain.Specification;
 
 @And({
         @Spec(path = "id", spec = Equal.class),
-        @Spec(path = "name", spec = Like.class),
+        @Spec(path = "name", spec = StartingWithIgnoreCase.class),
         @Spec(path = "companyType", params = "company-type", spec = Equal.class)
 })
 public interface DeveloperSpecification extends Specification<Developer> {

--- a/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/FranchiseSpecification.java
+++ b/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/FranchiseSpecification.java
@@ -1,8 +1,7 @@
 package com.sparkystudios.traklibrary.game.repository.specification;
 
-import com.sparkystudios.traklibrary.game.domain.Game;
+import com.sparkystudios.traklibrary.game.domain.Franchise;
 import net.kaczmarzyk.spring.data.jpa.domain.Equal;
-import net.kaczmarzyk.spring.data.jpa.domain.LikeIgnoreCase;
 import net.kaczmarzyk.spring.data.jpa.domain.StartingWithIgnoreCase;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.And;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
@@ -10,8 +9,7 @@ import org.springframework.data.jpa.domain.Specification;
 
 @And({
         @Spec(path = "id", spec = Equal.class),
-        @Spec(path = "title", spec = StartingWithIgnoreCase.class),
-        @Spec(path = "ageRating", params = "age-rating", spec = Equal.class)
+        @Spec(path = "title", spec = StartingWithIgnoreCase.class)
 })
-public interface GameSpecification extends Specification<Game> {
+public interface FranchiseSpecification extends Specification<Franchise> {
 }

--- a/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/GameRequestSpecification.java
+++ b/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/GameRequestSpecification.java
@@ -3,13 +3,14 @@ package com.sparkystudios.traklibrary.game.repository.specification;
 import com.sparkystudios.traklibrary.game.domain.GameRequest;
 import net.kaczmarzyk.spring.data.jpa.domain.Equal;
 import net.kaczmarzyk.spring.data.jpa.domain.Like;
+import net.kaczmarzyk.spring.data.jpa.domain.StartingWithIgnoreCase;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.And;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
 import org.springframework.data.jpa.domain.Specification;
 
 @And({
         @Spec(path = "id", spec = Equal.class),
-        @Spec(path = "title", spec = Like.class),
+        @Spec(path = "title", spec = StartingWithIgnoreCase.class),
         @Spec(path = "completed", spec = Equal.class),
         @Spec(path = "completedDate", params = "completed-date", spec = Equal.class),
         @Spec(path = "userId", params = "user-id", spec = Equal.class)

--- a/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/GameRequestSpecification.java
+++ b/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/GameRequestSpecification.java
@@ -2,7 +2,6 @@ package com.sparkystudios.traklibrary.game.repository.specification;
 
 import com.sparkystudios.traklibrary.game.domain.GameRequest;
 import net.kaczmarzyk.spring.data.jpa.domain.Equal;
-import net.kaczmarzyk.spring.data.jpa.domain.Like;
 import net.kaczmarzyk.spring.data.jpa.domain.StartingWithIgnoreCase;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.And;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;

--- a/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/GameSpecification.java
+++ b/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/GameSpecification.java
@@ -2,7 +2,6 @@ package com.sparkystudios.traklibrary.game.repository.specification;
 
 import com.sparkystudios.traklibrary.game.domain.Game;
 import net.kaczmarzyk.spring.data.jpa.domain.Equal;
-import net.kaczmarzyk.spring.data.jpa.domain.LikeIgnoreCase;
 import net.kaczmarzyk.spring.data.jpa.domain.StartingWithIgnoreCase;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.And;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;

--- a/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/GenreSpecification.java
+++ b/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/GenreSpecification.java
@@ -2,7 +2,6 @@ package com.sparkystudios.traklibrary.game.repository.specification;
 
 import com.sparkystudios.traklibrary.game.domain.Genre;
 import net.kaczmarzyk.spring.data.jpa.domain.Equal;
-import net.kaczmarzyk.spring.data.jpa.domain.Like;
 import net.kaczmarzyk.spring.data.jpa.domain.StartingWithIgnoreCase;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.And;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;

--- a/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/GenreSpecification.java
+++ b/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/GenreSpecification.java
@@ -3,13 +3,14 @@ package com.sparkystudios.traklibrary.game.repository.specification;
 import com.sparkystudios.traklibrary.game.domain.Genre;
 import net.kaczmarzyk.spring.data.jpa.domain.Equal;
 import net.kaczmarzyk.spring.data.jpa.domain.Like;
+import net.kaczmarzyk.spring.data.jpa.domain.StartingWithIgnoreCase;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.And;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
 import org.springframework.data.jpa.domain.Specification;
 
 @And({
         @Spec(path = "id", spec = Equal.class),
-        @Spec(path = "name", spec = Like.class)
+        @Spec(path = "name", spec = StartingWithIgnoreCase.class)
 })
 public interface GenreSpecification extends Specification<Genre> {
 }

--- a/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/PlatformSpecification.java
+++ b/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/PlatformSpecification.java
@@ -2,7 +2,6 @@ package com.sparkystudios.traklibrary.game.repository.specification;
 
 import com.sparkystudios.traklibrary.game.domain.Platform;
 import net.kaczmarzyk.spring.data.jpa.domain.Equal;
-import net.kaczmarzyk.spring.data.jpa.domain.Like;
 import net.kaczmarzyk.spring.data.jpa.domain.StartingWithIgnoreCase;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.And;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;

--- a/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/PlatformSpecification.java
+++ b/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/PlatformSpecification.java
@@ -3,13 +3,14 @@ package com.sparkystudios.traklibrary.game.repository.specification;
 import com.sparkystudios.traklibrary.game.domain.Platform;
 import net.kaczmarzyk.spring.data.jpa.domain.Equal;
 import net.kaczmarzyk.spring.data.jpa.domain.Like;
+import net.kaczmarzyk.spring.data.jpa.domain.StartingWithIgnoreCase;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.And;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
 import org.springframework.data.jpa.domain.Specification;
 
 @And({
         @Spec(path = "id", spec = Equal.class),
-        @Spec(path = "name", spec = Like.class)
+        @Spec(path = "name", spec = StartingWithIgnoreCase.class)
 })
 public interface PlatformSpecification extends Specification<Platform> {
 }

--- a/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/PublisherSpecification.java
+++ b/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/PublisherSpecification.java
@@ -2,7 +2,6 @@ package com.sparkystudios.traklibrary.game.repository.specification;
 
 import com.sparkystudios.traklibrary.game.domain.Publisher;
 import net.kaczmarzyk.spring.data.jpa.domain.Equal;
-import net.kaczmarzyk.spring.data.jpa.domain.Like;
 import net.kaczmarzyk.spring.data.jpa.domain.StartingWithIgnoreCase;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.And;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;

--- a/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/PublisherSpecification.java
+++ b/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/specification/PublisherSpecification.java
@@ -3,13 +3,14 @@ package com.sparkystudios.traklibrary.game.repository.specification;
 import com.sparkystudios.traklibrary.game.domain.Publisher;
 import net.kaczmarzyk.spring.data.jpa.domain.Equal;
 import net.kaczmarzyk.spring.data.jpa.domain.Like;
+import net.kaczmarzyk.spring.data.jpa.domain.StartingWithIgnoreCase;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.And;
 import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
 import org.springframework.data.jpa.domain.Specification;
 
 @And({
         @Spec(path = "id", spec = Equal.class),
-        @Spec(path = "name", spec = Like.class),
+        @Spec(path = "name", spec = StartingWithIgnoreCase.class),
         @Spec(path = "companyType", params = "company-type", spec = Equal.class)
 })
 public interface PublisherSpecification extends Specification<Publisher> {

--- a/game-server/pom.xml
+++ b/game-server/pom.xml
@@ -63,8 +63,8 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/assembler/FranchiseRepresentationModelAssembler.java
+++ b/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/assembler/FranchiseRepresentationModelAssembler.java
@@ -1,0 +1,42 @@
+package com.sparkystudios.traklibrary.game.server.assembler;
+
+import com.sparkystudios.traklibrary.game.server.controller.FranchiseController;
+import com.sparkystudios.traklibrary.game.service.dto.FranchiseDto;
+import com.sparkystudios.traklibrary.game.service.dto.GameDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.SimpleRepresentationModelAssembler;
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+@RequiredArgsConstructor
+@Component
+public class FranchiseRepresentationModelAssembler implements SimpleRepresentationModelAssembler<FranchiseDto> {
+
+    private final PagedResourcesAssembler<GameDto> gameDtoPagedResourcesAssembler;
+
+    @Override
+    public void addLinks(EntityModel<FranchiseDto> resource) {
+        FranchiseDto content = resource.getContent();
+
+        // Only add content if a valid model has been provided.
+        if (content != null) {
+            resource.add(WebMvcLinkBuilder.linkTo(methodOn(FranchiseController.class).findById(content.getId()))
+                    .withSelfRel());
+
+            resource.add(WebMvcLinkBuilder.linkTo(methodOn(FranchiseController.class).findGamesByFranchiseId(content.getId(), Pageable.unpaged(), gameDtoPagedResourcesAssembler))
+                    .withRel("games"));
+        }
+    }
+
+    @Override
+    public void addLinks(@NonNull CollectionModel<EntityModel<FranchiseDto>> resources) {
+        // Unused. Additional resource links aren't added to collections.
+    }
+}

--- a/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/assembler/GameDetailsRepresentationModelAssembler.java
+++ b/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/assembler/GameDetailsRepresentationModelAssembler.java
@@ -1,5 +1,6 @@
 package com.sparkystudios.traklibrary.game.server.assembler;
 
+import com.sparkystudios.traklibrary.game.server.controller.FranchiseController;
 import com.sparkystudios.traklibrary.game.server.controller.GameController;
 import com.sparkystudios.traklibrary.game.service.dto.GameDetailsDto;
 import com.sparkystudios.traklibrary.game.service.dto.GameUserEntryDto;
@@ -48,6 +49,11 @@ public class GameDetailsRepresentationModelAssembler implements SimpleRepresenta
 
             resource.add(linkTo(methodOn(GameController.class).findGameUserEntriesByGameId(content.getId(), Pageable.unpaged(), gameUserEntryDtoPagedResourcesAssembler))
                     .withRel("entries"));
+
+            if (content.getFranchiseId() != null) {
+                resource.add(linkTo(methodOn(FranchiseController.class).findById(content.getFranchiseId()))
+                        .withRel("franchise"));
+            }
         }
     }
 

--- a/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/assembler/GameRepresentationModelAssembler.java
+++ b/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/assembler/GameRepresentationModelAssembler.java
@@ -1,5 +1,6 @@
 package com.sparkystudios.traklibrary.game.server.assembler;
 
+import com.sparkystudios.traklibrary.game.server.controller.FranchiseController;
 import com.sparkystudios.traklibrary.game.server.controller.GameController;
 import com.sparkystudios.traklibrary.game.service.dto.GameDto;
 import com.sparkystudios.traklibrary.game.service.dto.GameUserEntryDto;
@@ -51,6 +52,11 @@ public class GameRepresentationModelAssembler implements SimpleRepresentationMod
 
             resource.add(linkTo(methodOn(GameController.class).findGameDetailsByGameId(content.getId()))
                     .withRel("info"));
+
+            if (content.getFranchiseId() != null) {
+                resource.add(linkTo(methodOn(FranchiseController.class).findById(content.getFranchiseId()))
+                        .withRel("franchise"));
+            }
         }
     }
 

--- a/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/controller/FranchiseController.java
+++ b/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/controller/FranchiseController.java
@@ -1,0 +1,206 @@
+package com.sparkystudios.traklibrary.game.server.controller;
+
+import com.sparkystudios.traklibrary.game.repository.specification.FranchiseSpecification;
+import com.sparkystudios.traklibrary.game.repository.specification.GenreSpecification;
+import com.sparkystudios.traklibrary.game.server.assembler.FranchiseRepresentationModelAssembler;
+import com.sparkystudios.traklibrary.game.server.assembler.GameRepresentationModelAssembler;
+import com.sparkystudios.traklibrary.game.service.FranchiseService;
+import com.sparkystudios.traklibrary.game.service.GameService;
+import com.sparkystudios.traklibrary.game.service.dto.FranchiseDto;
+import com.sparkystudios.traklibrary.game.service.dto.GameDto;
+import com.sparkystudios.traklibrary.security.annotation.AllowedForModerator;
+import com.sparkystudios.traklibrary.security.annotation.AllowedForUser;
+import com.sparkystudios.traklibrary.security.exception.ApiError;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.PagedModel;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import javax.json.JsonMergePatch;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping(value = "/franchises", produces = "application/vnd.traklibrary.v1.hal+json")
+public class FranchiseController {
+
+    private final FranchiseService franchiseService;
+    private final GameService gameService;
+    private final FranchiseRepresentationModelAssembler franchiseRepresentationModelAssembler;
+    private final GameRepresentationModelAssembler gameRepresentationModelAssembler;
+
+    /**
+     * End-point that will attempt to save the given {@link FranchiseDto} request body to the underlying
+     * persistence layer. The {@link FranchiseDto} must either be valid or have all of the required fields meet
+     * its pre-requisite conditions in order to attempt a save to the persistence layer.
+     *
+     * If the {@link FranchiseDto} being saved contains an ID that matches an existing entity in the persistence layer,
+     * the {@link FranchiseDto} will not be saved and a {@link ApiError} will
+     * be returned with appropriate exceptions details.
+     *
+     * @param franchiseDto The {@link FranchiseDto} to save.
+     *
+     * @return The saved {@link FranchiseDto} instance as a HATEOAS response.
+     */
+    @AllowedForModerator
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    public EntityModel<FranchiseDto> save(@Validated @RequestBody FranchiseDto franchiseDto) {
+        return franchiseRepresentationModelAssembler.toModel(franchiseService.save(franchiseDto));
+    }
+
+    /**
+     * End-point that will retrieve a {@link FranchiseDto} instance that matches the given ID and convert
+     * it into a consumable HATEOAS response. If a {@link FranchiseDto} instance is found that matches the ID, then
+     * that data is returned with a status of 200, however if the {@link FranchiseDto} cannot be found the method
+     * will return a 404 and wrap the exception details in a {@link ApiError} with additional information.
+     *
+     * @param id The ID of the {@link FranchiseDto} to retrieve.
+     *
+     * @return The {@link FranchiseDto} that matches the given ID as a HATEOAS response.
+     */
+    @AllowedForUser
+    @GetMapping("/{id}")
+    public EntityModel<FranchiseDto> findById(@PathVariable long id) {
+        return franchiseRepresentationModelAssembler.toModel(franchiseService.findById(id));
+    }
+
+    /**
+     * End-point that will retrieve a {@link PagedModel} of {@link GameDto}s that have a link to the specified
+     * {@link FranchiseDto}. If the ID doesn't match an existing {@link FranchiseDto}, then an {@link ApiError} will be
+     * returned with additional error details. If the {@link FranchiseDto} exists but has no associated
+     * {@link GameDto}'s, then an empty {@link PagedModel} will be returned.
+     *
+     * @param id The ID of the {@link FranchiseDto} to retrieve associated {@link GameDto}'s for.
+     * @param pageable The size and ordering of the page to retrieve.
+     * @param pagedResourcesAssembler The assembler used to convert the {@link GameDto}'s to a HATEOAS page.
+     *
+     * @return A {@link PagedModel} of {@link GameDto}'s that are associated with the given {@link FranchiseDto}.
+     */
+    @AllowedForUser
+    @GetMapping("/{id}/games")
+    public PagedModel<EntityModel<GameDto>> findGamesByFranchiseId(@PathVariable long id,
+                                                                   @PageableDefault Pageable pageable,
+                                                                   PagedResourcesAssembler<GameDto> pagedResourcesAssembler) {
+        // The self, next and prev links won't include query parameters if not built manually.
+        Link link = new Link(ServletUriComponentsBuilder.fromCurrentRequest().build()
+                .toUriString())
+                .withSelfRel();
+
+        // Get the paged data from the service and convert into a list so it can be added to a page object.
+        List<GameDto> gameDtos = StreamSupport.stream(gameService.findGamesByFranchiseId(id, pageable).spliterator(), false)
+                .collect(Collectors.toList());
+
+        // Get the total number of entities that match the given criteria, dis-regarding page sizing.
+        long count = gameService.countGamesByFranchiseId(id);
+
+        // Wrap the page in a HATEOAS response.
+        return pagedResourcesAssembler
+                .toModel(new PageImpl<>(gameDtos, pageable, count), gameRepresentationModelAssembler, link);
+    }
+
+    /**
+     * End-point that can be used to retrieve a paged result of {@link FranchiseDto} instances, that are filtered by
+     * the provided {@link GenreSpecification} which appear as request parameters on the URL. The page and each
+     * {@link FranchiseDto} will be wrapped in a HATEOAS response. If no {@link FranchiseDto} match the given criteria,
+     * an empty HATEOAS page response will be returned.
+     *
+     * If any exceptions are thrown internally, and {@link ApiError} response will be returned with additional
+     * error details.
+     *
+     * @param franchiseSpecification The filter queries to filter the page by.
+     * @param pageable The size, page and ordering of the {@link FranchiseDto} elements in the page.
+     * @param pagedResourcesAssembler Injected, used to convert the {@link FranchiseDto}s into a {@link PagedModel}.
+     *
+     * @return A {@link PagedModel} containing the {@link FranchiseDto} that match the requested page and criteria.
+     */
+    @AllowedForUser
+    @GetMapping
+    public PagedModel<EntityModel<FranchiseDto>> findAll(FranchiseSpecification franchiseSpecification,
+                                                         @PageableDefault Pageable pageable,
+                                                         PagedResourcesAssembler<FranchiseDto> pagedResourcesAssembler) {
+        // The self, next and prev links won't include query parameters if not built manually.
+        Link link = new Link(ServletUriComponentsBuilder.fromCurrentRequest().build()
+                .toUriString())
+                .withSelfRel();
+
+        // Get the paged data from the service and convert into a list so it can be added to a page object.
+        List<FranchiseDto> franchiseDtos = StreamSupport.stream(franchiseService.findAll(franchiseSpecification, pageable).spliterator(), false)
+                .collect(Collectors.toList());
+
+        // Get the total number of entities that match the given criteria, dis-regarding page sizing.
+        long count = franchiseService.count(franchiseSpecification);
+
+        // Wrap the page in a HATEOAS response.
+        return pagedResourcesAssembler
+                .toModel(new PageImpl<>(franchiseDtos, pageable, count), franchiseRepresentationModelAssembler, link);
+    }
+
+    /**
+     * End-point that will attempt to updated the given {@link FranchiseDto} request body to the underlying
+     * persistence layer. The {@link FranchiseDto} must either be valid or have all of the required fields meet
+     * its pre-requisite conditions in order to attempt an update in the persistence layer.
+     *
+     * If the {@link FranchiseDto} being saved doesn't contain an ID that matches an existing entity in the persistence layer,
+     * the {@link FranchiseDto} will not be updated and a {@link ApiError} will be returned with appropriate exceptions details.
+     *
+     * @param franchiseDto The {@link FranchiseDto} to updated.
+     *
+     * @return The updated {@link FranchiseDto} instance as a HATEOAS response.
+     */
+    @AllowedForModerator
+    @PutMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    public EntityModel<FranchiseDto> update(@Validated @RequestBody FranchiseDto franchiseDto) {
+        return franchiseRepresentationModelAssembler.toModel(franchiseService.update(franchiseDto));
+    }
+
+    /**
+     * End-point that will attempt to patch the {@link FranchiseDto} that matches the given ID with the values
+     * specified within the {@link JsonMergePatch}. The {@link JsonMergePatch} must contain valid data to be applied
+     * to the {@link FranchiseDto}, otherwise an {@link ApiError} will be returned to the user with additional exception
+     * data.
+     *
+     * The {@link JsonMergePatch} provided can contain JSON data that is not contained within the {@link FranchiseDto},
+     * however it will not apply any unknown field, but instead ignore them. If the ID provided does not match
+     * a {@link FranchiseDto} or the patch fails to apply, {@link ApiError} instances will be returned with additional
+     * error information.
+     *
+     * @param id The ID of the {@link FranchiseDto} to patch.
+     * @param jsonMergePatch The {@link JsonMergePatch} which contains JSON data to update the {@link FranchiseDto} with.
+     *
+     * @return The patched {@link FranchiseDto} instance.
+     */
+    @AllowedForModerator
+    @PatchMapping(value = "/{id}", consumes = "application/merge-patch+json")
+    public EntityModel<FranchiseDto> patch(@PathVariable long id, @RequestBody JsonMergePatch jsonMergePatch) {
+        return franchiseRepresentationModelAssembler.toModel(franchiseService.patch(id, jsonMergePatch));
+    }
+
+    /**
+     * End-point that will attempt to the delete the {@link FranchiseDto} instance associated with the given ID. If no {@link FranchiseDto}
+     * is found that matches the ID, then an exception will be thrown and the end-point will return a {@link ApiError} along with
+     * additional information.
+     *
+     * If the {@link FranchiseDto} is successfully deleted, no data will be returned but the endpoint will specify a response code of 204
+     * (NO_CONTENT).
+     *
+     * @param id The ID of the {@link FranchiseDto} to delete.
+     */
+    @AllowedForModerator
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/{id}")
+    public void deleteById(@PathVariable long id) {
+        franchiseService.deleteById(id);
+    }
+}

--- a/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/controller/GameBarcodeController.java
+++ b/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/controller/GameBarcodeController.java
@@ -6,6 +6,7 @@ import com.sparkystudios.traklibrary.game.service.GameBarcodeService;
 import com.sparkystudios.traklibrary.game.service.GameService;
 import com.sparkystudios.traklibrary.game.service.dto.GameBarcodeDto;
 import com.sparkystudios.traklibrary.security.annotation.AllowedForUser;
+import com.sparkystudios.traklibrary.security.exception.ApiError;
 import lombok.RequiredArgsConstructor;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.MediaTypes;

--- a/game-server/src/main/resources/i18n/exception.properties
+++ b/game-server/src/main/resources/i18n/exception.properties
@@ -4,6 +4,9 @@ company.exception.not-found=Unable to find Company with parameter: id={0}
 developer.exception.entity-exists=Cannot save a new Developer over an existing one. ID already exists: id={0}
 developer.exception.not-found=Unable to find Developer with parameter: id={0}
 
+franchise.exception.entity-exists=Cannot save a new Franchise over an existing one. ID already exists: id={0}
+franchise.exception.not-found=Unable to find Franchise with parameter: id={0}
+
 game.exception.entity-exists=Cannot save a new Game over an existing one. ID already exists: id={0}
 game.exception.not-found=Unable to find Game with parameter: id={0}
 

--- a/game-server/src/main/resources/i18n/exception_en.properties
+++ b/game-server/src/main/resources/i18n/exception_en.properties
@@ -4,6 +4,9 @@ company.exception.not-found=Unable to find Company with parameter: id={0}
 developer.exception.entity-exists=Cannot save a new Developer over an existing one. ID already exists: id={0}
 developer.exception.not-found=Unable to find Developer with parameter: id={0}
 
+franchise.exception.entity-exists=Cannot save a new Franchise over an existing one. ID already exists: id={0}
+franchise.exception.not-found=Unable to find Franchise with parameter: id={0}
+
 game.exception.entity-exists=Cannot save a new Game over an existing one. ID already exists: id={0}
 game.exception.not-found=Unable to find Game with parameter: id={0}
 

--- a/game-server/src/main/resources/i18n/validation.properties
+++ b/game-server/src/main/resources/i18n/validation.properties
@@ -3,6 +3,9 @@ company.validation.description.size=The description cannot exceed 4096 character
 company.validation.founded-date.not-null=The founded date cannot be null.
 company.validation.company-type.not-null=The company type cannot be null.
 
+franchise.validation.title.not-empty=The title cannot be empty or null.
+franchise.validation.title.size=The description cannot exceed 255 characters.
+
 game.validation.title.not-empty=The title cannot be empty or null.
 game.validation.description.size=The description cannot exceed 4096 characters.
 game.validation.age-rating-not-null=The age rating cannot be null.

--- a/game-server/src/main/resources/i18n/validation_en.properties
+++ b/game-server/src/main/resources/i18n/validation_en.properties
@@ -3,6 +3,9 @@ company.validation.description.size=The description cannot exceed 4096 character
 company.validation.founded-date.not-null=The founded date cannot be null.
 company.validation.company-type.not-null=The company type cannot be null.
 
+franchise.validation.title.not-empty=The title cannot be empty or null.
+franchise.validation.title.size=The description cannot exceed 255 characters.
+
 game.validation.title.not-empty=The title cannot be empty or null.
 game.validation.description.size=The description cannot exceed 4096 characters.
 game.validation.age-rating-not-null=The age rating cannot be null.

--- a/game-server/src/test/java/com/sparkystudios/traklibrary/game/server/controller/FranchiseControllerTest.java
+++ b/game-server/src/test/java/com/sparkystudios/traklibrary/game/server/controller/FranchiseControllerTest.java
@@ -1,0 +1,461 @@
+package com.sparkystudios.traklibrary.game.server.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparkystudios.traklibrary.game.domain.AgeRating;
+import com.sparkystudios.traklibrary.game.server.assembler.FranchiseRepresentationModelAssembler;
+import com.sparkystudios.traklibrary.game.server.assembler.GameRepresentationModelAssembler;
+import com.sparkystudios.traklibrary.game.server.configuration.TrakHalJsonMediaTypeConfiguration;
+import com.sparkystudios.traklibrary.game.server.converter.JsonMergePatchHttpMessageConverter;
+import com.sparkystudios.traklibrary.game.server.exception.GlobalExceptionHandler;
+import com.sparkystudios.traklibrary.game.server.utils.ResponseVerifier;
+import com.sparkystudios.traklibrary.game.service.FranchiseService;
+import com.sparkystudios.traklibrary.game.service.GameService;
+import com.sparkystudios.traklibrary.game.service.dto.FranchiseDto;
+import com.sparkystudios.traklibrary.game.service.dto.GameDto;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+
+@Import({FranchiseController.class, TrakHalJsonMediaTypeConfiguration.class, GlobalExceptionHandler.class, JsonMergePatchHttpMessageConverter.class})
+@WebMvcTest(controllers = FranchiseController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class, useDefaultFilters = false)
+@AutoConfigureMockMvc(addFilters = false)
+public class FranchiseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private FranchiseService franchiseService;
+
+    @MockBean
+    private GameService gameService;
+
+    @TestConfiguration
+    static class TestConfig {
+
+        @Bean
+        public FranchiseRepresentationModelAssembler franchiseRepresentationModelAssembler() {
+            return new FranchiseRepresentationModelAssembler(null);
+        }
+
+        @Bean
+        public GameRepresentationModelAssembler gameRepresentationModelAssembler() {
+            return new GameRepresentationModelAssembler(null);
+        }
+    }
+
+    @Test
+    void save_withInvalidFranchiseDto_returns400() throws Exception {
+        // Act
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.post("/franchises")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept("application/vnd.traklibrary.v1.hal+json")
+                .content(objectMapper.writeValueAsString(new FranchiseDto())));
+
+        // Assert
+        resultActions
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.status", Matchers.is(HttpStatus.BAD_REQUEST.name())))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.time").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.error").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.details").exists());
+    }
+
+    @Test
+    void save_withValidFranchiseDto_returns201AndValidResponse() throws Exception {
+        // Arrange
+        FranchiseDto franchiseDto = new FranchiseDto();
+        franchiseDto.setId(1L);
+        franchiseDto.setTitle("test-name-1");
+        franchiseDto.setDescription("test-description-1");
+        franchiseDto.setCreatedAt(LocalDateTime.now());
+        franchiseDto.setUpdatedAt(LocalDateTime.now());
+        franchiseDto.setVersion(1L);
+
+        Mockito.when(franchiseService.save(ArgumentMatchers.any()))
+                .thenReturn(franchiseDto);
+
+        // Act
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.post("/franchises")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept("application/vnd.traklibrary.v1.hal+json")
+                .content(objectMapper.writeValueAsString(franchiseDto)));
+
+        // Assert
+        resultActions
+                .andExpect(MockMvcResultMatchers.status().isCreated());
+
+        ResponseVerifier.verifyFranchiseDto("", resultActions, franchiseDto);
+    }
+
+    @Test
+    void findById_withValidId_return200AndValidResponse() throws Exception {
+        // Arrange
+        FranchiseDto franchiseDto = new FranchiseDto();
+        franchiseDto.setId(1L);
+        franchiseDto.setTitle("test-title-1");
+        franchiseDto.setDescription("test-description-1");
+        franchiseDto.setCreatedAt(LocalDateTime.now());
+        franchiseDto.setUpdatedAt(LocalDateTime.now());
+        franchiseDto.setVersion(1L);
+
+        Mockito.when(franchiseService.findById(ArgumentMatchers.anyLong()))
+                .thenReturn(franchiseDto);
+
+        // Act
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/franchises/1")
+                .accept("application/vnd.traklibrary.v1.hal+json"));
+
+        // Assert
+        resultActions
+                .andExpect(MockMvcResultMatchers.status().isOk());
+
+        ResponseVerifier.verifyFranchiseDto("", resultActions, franchiseDto);
+    }
+
+    @Test
+    void findGamesByFranchiseId_withNoData_returns200AndEmptyPagedResponse() throws Exception {
+        // Arrange
+        Mockito.when(gameService.findGamesByFranchiseId(ArgumentMatchers.anyLong(), ArgumentMatchers.any()))
+                .thenReturn(Collections.emptyList());
+
+        Mockito.when(gameService.countGamesByFranchiseId(ArgumentMatchers.anyLong()))
+                .thenReturn(0L);
+
+        // Act
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/franchises/1/games")
+                .accept("application/vnd.traklibrary.v1.hal+json"));
+
+        // Assert
+        resultActions
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._embedded").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.self").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.last").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.next").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.prev").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.size").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalElements", Matchers.is(0)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
+    }
+
+    @Test
+    void findGamesByFranchiseId_withSmallData_returns200AndValidPagedResponseWithNoPageLinks() throws Exception {
+        // Arrange
+        GameDto gameDto1 = new GameDto();
+        gameDto1.setId(1L);
+        gameDto1.setTitle("test-title-1");
+        gameDto1.setDescription("test-description-1");
+        gameDto1.setAgeRating(AgeRating.EVERYONE_TEN_PLUS);
+        gameDto1.setCreatedAt(LocalDateTime.now());
+        gameDto1.setUpdatedAt(LocalDateTime.now());
+        gameDto1.setVersion(1L);
+
+        GameDto gameDto2 = new GameDto();
+        gameDto2.setId(2L);
+        gameDto2.setTitle("test-title-2");
+        gameDto2.setDescription("test-description-2");
+        gameDto2.setAgeRating(AgeRating.ADULTS_ONLY);
+        gameDto2.setCreatedAt(LocalDateTime.now());
+        gameDto2.setUpdatedAt(LocalDateTime.now());
+        gameDto2.setVersion(2L);
+
+        Mockito.when(gameService.findGamesByFranchiseId(ArgumentMatchers.anyLong(), ArgumentMatchers.any()))
+                .thenReturn(Arrays.asList(gameDto1, gameDto2));
+
+        Mockito.when(gameService.countGamesByFranchiseId(ArgumentMatchers.anyLong()))
+                .thenReturn(2L);
+
+        // Act
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/franchises/1/games")
+                .accept("application/vnd.traklibrary.v1.hal+json"));
+
+        // Assert
+        resultActions
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.self").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.last").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.next").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.prev").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.size").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalElements", Matchers.is(2)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
+
+        ResponseVerifier.verifyGameDto("._embedded.data[0]", resultActions, gameDto1);
+        ResponseVerifier.verifyGameDto("._embedded.data[1]", resultActions, gameDto2);
+    }
+
+    @Test
+    void findGamesByFranchiseId_withData_returns200AndValidPagedResponseWithPageLinks() throws Exception {
+        // Arrange
+        GameDto gameDto1 = new GameDto();
+        gameDto1.setId(1L);
+        gameDto1.setTitle("test-title-1");
+        gameDto1.setDescription("test-description-1");
+        gameDto1.setAgeRating(AgeRating.EVERYONE_TEN_PLUS);
+        gameDto1.setCreatedAt(LocalDateTime.now());
+        gameDto1.setUpdatedAt(LocalDateTime.now());
+        gameDto1.setVersion(1L);
+
+        GameDto gameDto2 = new GameDto();
+        gameDto2.setId(2L);
+        gameDto2.setTitle("test-title-2");
+        gameDto2.setDescription("test-description-2");
+        gameDto2.setAgeRating(AgeRating.ADULTS_ONLY);
+        gameDto2.setCreatedAt(LocalDateTime.now());
+        gameDto2.setUpdatedAt(LocalDateTime.now());
+        gameDto2.setVersion(2L);
+
+        Mockito.when(gameService.findGamesByFranchiseId(ArgumentMatchers.anyLong(), ArgumentMatchers.any()))
+                .thenReturn(Arrays.asList(gameDto1, gameDto2));
+
+        Mockito.when(gameService.countGamesByFranchiseId(ArgumentMatchers.anyLong()))
+                .thenReturn(100L);
+
+        // Act
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/franchises/1/games?page=2")
+                .accept("application/vnd.traklibrary.v1.hal+json"));
+
+        // Assert
+        resultActions
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.self").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.last").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.next").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.prev").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.size").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalElements", Matchers.is(100)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
+
+        ResponseVerifier.verifyGameDto("._embedded.data[0]", resultActions, gameDto1);
+        ResponseVerifier.verifyGameDto("._embedded.data[1]", resultActions, gameDto2);
+    }
+
+    @Test
+    void findAll_withNoData_returns200AndEmptyPagedResponse() throws Exception {
+        // Arrange
+        Mockito.when(franchiseService.findAll(ArgumentMatchers.any(), ArgumentMatchers.any()))
+                .thenReturn(Collections.emptyList());
+
+        Mockito.when(franchiseService.count(ArgumentMatchers.any()))
+                .thenReturn(0L);
+
+        // Act
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/franchises")
+                .accept("application/vnd.traklibrary.v1.hal+json"));
+
+        // Assert
+        resultActions
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._embedded").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.self").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.last").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.next").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.prev").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.size").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalElements", Matchers.is(0)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
+    }
+
+    @Test
+    void findAll_withSmallData_returns200AndValidPagedResponseWithNoPageLinks() throws Exception {
+        // Arrange
+        FranchiseDto franchiseDto1 = new FranchiseDto();
+        franchiseDto1.setId(1L);
+        franchiseDto1.setTitle("test-title-1");
+        franchiseDto1.setDescription("test-description-1");
+        franchiseDto1.setCreatedAt(LocalDateTime.now());
+        franchiseDto1.setUpdatedAt(LocalDateTime.now());
+        franchiseDto1.setVersion(1L);
+
+        FranchiseDto franchiseDto2 = new FranchiseDto();
+        franchiseDto2.setId(2L);
+        franchiseDto2.setTitle("test-title-2");
+        franchiseDto2.setDescription("test-description-2");
+        franchiseDto2.setCreatedAt(LocalDateTime.now());
+        franchiseDto2.setUpdatedAt(LocalDateTime.now());
+        franchiseDto2.setVersion(2L);
+
+        Mockito.when(franchiseService.findAll(ArgumentMatchers.any(), ArgumentMatchers.any()))
+                .thenReturn(Arrays.asList(franchiseDto1, franchiseDto2));
+
+        Mockito.when(franchiseService.count(ArgumentMatchers.any()))
+                .thenReturn(2L);
+
+        // Act
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/franchises")
+                .accept("application/vnd.traklibrary.v1.hal+json"));
+
+        // Assert
+        resultActions
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.self").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.last").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.next").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.prev").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.size").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalElements", Matchers.is(2)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
+
+        ResponseVerifier.verifyFranchiseDto("._embedded.data[0]", resultActions, franchiseDto1);
+        ResponseVerifier.verifyFranchiseDto("._embedded.data[1]", resultActions, franchiseDto2);
+    }
+
+    @Test
+    void findAll_withData_returns200AndValidPagedResponseWithPageLinks() throws Exception {
+        // Arrange
+        FranchiseDto franchiseDto1 = new FranchiseDto();
+        franchiseDto1.setId(1L);
+        franchiseDto1.setTitle("test-title-1");
+        franchiseDto1.setDescription("test-description-1");
+        franchiseDto1.setCreatedAt(LocalDateTime.now());
+        franchiseDto1.setUpdatedAt(LocalDateTime.now());
+        franchiseDto1.setVersion(1L);
+
+        FranchiseDto franchiseDto2 = new FranchiseDto();
+        franchiseDto2.setId(2L);
+        franchiseDto2.setTitle("test-title-2");
+        franchiseDto2.setDescription("test-description-2");
+        franchiseDto2.setCreatedAt(LocalDateTime.now());
+        franchiseDto2.setUpdatedAt(LocalDateTime.now());
+        franchiseDto2.setVersion(2L);
+
+        Mockito.when(franchiseService.findAll(ArgumentMatchers.any(), ArgumentMatchers.any()))
+                .thenReturn(Arrays.asList(franchiseDto1, franchiseDto2));
+
+        Mockito.when(franchiseService.count(ArgumentMatchers.any()))
+                .thenReturn(100L);
+
+        // Act
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/franchises?page=2")
+                .accept("application/vnd.traklibrary.v1.hal+json"));
+
+        // Assert
+        resultActions
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.self").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.last").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.next").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$._links.prev").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.size").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalElements", Matchers.is(100)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.totalPages").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.page.number").exists());
+
+        ResponseVerifier.verifyFranchiseDto("._embedded.data[0]", resultActions, franchiseDto1);
+        ResponseVerifier.verifyFranchiseDto("._embedded.data[1]", resultActions, franchiseDto2);
+    }
+
+    @Test
+    void update_withInvalidFranchiseDto_returns400() throws Exception {
+        // Act
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.put("/franchises")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept("application/vnd.traklibrary.v1.hal+json")
+                .content(objectMapper.writeValueAsString(new FranchiseDto())));
+
+        // Assert
+        resultActions
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.status", Matchers.is(HttpStatus.BAD_REQUEST.name())))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.time").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.error").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.details").exists());
+    }
+
+    @Test
+    void update_withValidFranchiseDto_returns200AndValidResponse() throws Exception {
+        // Arrange
+        FranchiseDto franchiseDto = new FranchiseDto();
+        franchiseDto.setId(1L);
+        franchiseDto.setTitle("test-title-1");
+        franchiseDto.setDescription("test-description-1");
+        franchiseDto.setCreatedAt(LocalDateTime.now());
+        franchiseDto.setUpdatedAt(LocalDateTime.now());
+        franchiseDto.setVersion(1L);
+
+        Mockito.when(franchiseService.update(ArgumentMatchers.any()))
+                .thenReturn(franchiseDto);
+
+        // Act
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.put("/franchises")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept("application/vnd.traklibrary.v1.hal+json")
+                .content(objectMapper.writeValueAsString(franchiseDto)));
+
+        // Assert
+        resultActions
+                .andExpect(MockMvcResultMatchers.status().isOk());
+
+        ResponseVerifier.verifyFranchiseDto("", resultActions, franchiseDto);
+    }
+
+    @Test
+    void patch_withValidPatch_returns200AndValidResponse() throws Exception {
+        // Arrange
+        FranchiseDto franchiseDto = new FranchiseDto();
+        franchiseDto.setId(1L);
+        franchiseDto.setTitle("test-title-1");
+        franchiseDto.setDescription("test-description-1");
+        franchiseDto.setCreatedAt(LocalDateTime.now());
+        franchiseDto.setUpdatedAt(LocalDateTime.now());
+        franchiseDto.setVersion(1L);
+
+        Mockito.when(franchiseService.patch(ArgumentMatchers.anyLong(), ArgumentMatchers.any()))
+                .thenReturn(franchiseDto);
+
+        // Act
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.patch("/franchises/1")
+                .contentType("application/merge-patch+json")
+                .accept("application/vnd.traklibrary.v1.hal+json")
+                .content("{ \"name\": \"test-name-2\" }"));
+
+        // Assert
+        resultActions
+                .andExpect(MockMvcResultMatchers.status().isOk());
+
+        ResponseVerifier.verifyFranchiseDto("", resultActions, franchiseDto);
+    }
+
+    @Test
+    void deleteById_withValidId_returns204() throws Exception {
+        // Arrange
+        Mockito.doNothing()
+                .when(franchiseService).deleteById(ArgumentMatchers.anyLong());
+
+        // Act
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.delete("/franchises/1")
+                .accept("application/vnd.traklibrary.v1.hal+json"));
+
+        // Assert
+        resultActions
+                .andExpect(MockMvcResultMatchers.status().isNoContent());
+    }
+}

--- a/game-server/src/test/java/com/sparkystudios/traklibrary/game/server/controller/FranchiseControllerTest.java
+++ b/game-server/src/test/java/com/sparkystudios/traklibrary/game/server/controller/FranchiseControllerTest.java
@@ -38,7 +38,7 @@ import java.util.Collections;
 @Import({FranchiseController.class, TrakHalJsonMediaTypeConfiguration.class, GlobalExceptionHandler.class, JsonMergePatchHttpMessageConverter.class})
 @WebMvcTest(controllers = FranchiseController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class, useDefaultFilters = false)
 @AutoConfigureMockMvc(addFilters = false)
-public class FranchiseControllerTest {
+class FranchiseControllerTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/game-server/src/test/java/com/sparkystudios/traklibrary/game/server/utils/ResponseVerifier.java
+++ b/game-server/src/test/java/com/sparkystudios/traklibrary/game/server/utils/ResponseVerifier.java
@@ -20,6 +20,18 @@ public class ResponseVerifier {
                 .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.games").exists());
     }
 
+    public static void verifyFranchiseDto(String root, ResultActions resultActions, FranchiseDto franchiseDto) throws Exception {
+        resultActions
+                .andExpect(MockMvcResultMatchers.jsonPath("$" + root + ".id", Matchers.is((int)franchiseDto.getId())))
+                .andExpect(MockMvcResultMatchers.jsonPath("$" + root + ".title", Matchers.is(franchiseDto.getTitle())))
+                .andExpect(MockMvcResultMatchers.jsonPath("$" + root + ".description", Matchers.is(franchiseDto.getDescription())))
+                .andExpect(MockMvcResultMatchers.jsonPath("$" + root + ".createdAt").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$" + root + ".updatedAt").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$" + root + ".version", Matchers.is((int)franchiseDto.getVersion().longValue())))
+                .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.self").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.games").exists());
+    }
+
     public static void verifyGameDto(String root, ResultActions resultActions, GameDto gameDto) throws Exception {
         resultActions
                 .andExpect(MockMvcResultMatchers.jsonPath("$" + root + ".id", Matchers.is((int)gameDto.getId())))

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/FranchiseService.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/FranchiseService.java
@@ -1,0 +1,125 @@
+package com.sparkystudios.traklibrary.game.service;
+
+import com.sparkystudios.traklibrary.game.domain.Franchise;
+import com.sparkystudios.traklibrary.game.repository.specification.FranchiseSpecification;
+import com.sparkystudios.traklibrary.game.service.dto.FranchiseDto;
+import org.springframework.data.domain.Pageable;
+
+import javax.json.JsonMergePatch;
+
+/**
+ * The {@link FranchiseService} follows the basic CRUD principle for interaction with {@link Franchise} entities on the persistence layer.
+ * However, the {@link FranchiseService} builds an additional layer of abstraction, with the primary purpose being checking the validity of
+ * {@link Franchise} data being requested from the persistence layer, as well as encapsulating any domain-based objects into {@link FranchiseDto}
+ * transfer objects, for additional validation and protection.
+ *
+ * The {@link FranchiseService} still follows the practise in that it will not catch or handle exceptions thrown by the persistence layer,
+ * instead it will wrap them in a more reasonable response and propagate the exception to the callee.
+ *
+ * @since 0.1.0
+ * @author Sparky Studios
+ */
+public interface FranchiseService {
+
+    /**
+     * Given a {@link FranchiseDto} instance, the service will attempt to persist the data with the underlying persistence layer.
+     * If the {@link FranchiseDto} supplied contains an Id that matches an existing entity, insertion to the persistence layer will
+     * fail and a {@link javax.persistence.EntityExistsException} will be thrown. If persistence succeeds, the data is saved and the
+     * saved entity is returned as a {@link FranchiseDto}.
+     *
+     * The method does not allow <code>null</code> entities to be inserted, if null is provided, a {@link NullPointerException}
+     * will be thrown.
+     *
+     * @param franchiseDto The {@link FranchiseDto} instance to persist.
+     *
+     * @return The updated persisted entity as a {@link FranchiseDto}.
+     *
+     * @throws NullPointerException Thrown if the argument provided is null.
+     */
+    FranchiseDto save(FranchiseDto franchiseDto);
+
+    /**
+     * Given an ID of a {@link Franchise} entity, this service method will query the underlying persistence layer and try and
+     * retrieve the {@link Franchise} entity that matches the given ID and map it to a {@link FranchiseDto}. If the ID provided does not
+     * map to any known {@link Franchise} entity, then an exception will be thrown specifying that it can't be found.
+     *
+     * @param id The ID of the {@link Franchise} entity to try and retrieve.
+     *
+     * @return The {@link Franchise} entity matching the ID mapped to a {@link FranchiseDto}.
+     *
+     * @throws javax.persistence.EntityNotFoundException Thrown if the ID doesn't match an existing {@link Franchise}.
+     */
+    FranchiseDto findById(long id);
+
+    /**
+     * This method will retrieve an {@link Iterable} of {@link FranchiseDto} with a response size specified by the {@link Pageable}. The
+     * results can be queried and filtered by utilising the exposed specifications on the {@link FranchiseSpecification} object. If the response
+     * from the specifications is that none match, an empty {@link Iterable} will be returned.
+     *
+     * The {@link FranchiseSpecification} argument can be omitted and is optional, however if the callee provides <code>null</code> for the
+     * {@link Pageable}, an exception will be thrown.
+     *
+     * @param franchiseSpecification The {@link FranchiseSpecification} to filter the query by.
+     * @param pageable The size and page of data to return.
+     *
+     * @return An {@link Iterable} of relevant queried {@link FranchiseDto} instances.
+     */
+    Iterable<FranchiseDto> findAll(FranchiseSpecification franchiseSpecification, Pageable pageable);
+
+    /**
+     * Retrieves the total number of rows that match the criteria specified within the {@link FranchiseSpecification}. The specification
+     * provided must be a valid instance, if <code>null</code> is provided, a {@link NullPointerException} will be thrown to the callee.
+     *
+     * @param franchiseSpecification The {@link FranchiseSpecification} criteria to count the results for.
+     *
+     * @return The total number of rows that matches the given criteria.
+     */
+    long count(FranchiseSpecification franchiseSpecification);
+
+    /**
+     * Given a {@link FranchiseDto} instance, the service will attempt to the update the persisted data which matches the given {@link FranchiseDto}
+     * in the underlying persistence layer. If the {@link FranchiseDto} supplied contains an ID that doesn't match any existing entities, then
+     * the update will fail and a {@link javax.persistence.EntityNotFoundException} will be thrown. If persistence succeeds, the relevant
+     * record is updated and the updated entity is returned as a {@link FranchiseDto}.
+     *
+     * The method does not allow <code>null</code> entities to be inserted, if null is provided, a {@link NullPointerException}
+     * will be thrown.
+     *
+     * @param franchiseDto The {@link FranchiseDto} instance to update.
+     *
+     * @return The updated persisted entity as a {@link FranchiseDto}.
+     *
+     * @throws NullPointerException Thrown if the {@link FranchiseDto} argument provided is null.
+     */
+    FranchiseDto update(FranchiseDto franchiseDto);
+
+    /**
+     * Given a {@link JsonMergePatch} which will contain JSON information pertaining to a {@link FranchiseDto}, this method will attempt to retrieve
+     * the {@link FranchiseDto} that matches the given ID and apply the new JSON on top of it. If the ID provided doesn't match any existing entities,
+     * then the patch will fail and a {@link javax.persistence.EntityNotFoundException} will be thrown. If the {@link JsonMergePatch} contains any
+     * JSON data not contained on the {@link FranchiseDto}, it'll be ignored. If the patching succeeds, the patched record will be updated and the updated
+     * entity returned as a {@link FranchiseDto}.
+     *
+     * The method does not allow a null {@link JsonMergePatch} to be provided, if null is provided, a {@link NullPointerException} will be thrown.
+     *
+     * @param id The ID of the {@link FranchiseDto} to patch.
+     * @param jsonMergePatch The {@link JsonMergePatch} containing the JSON data to patch.
+     *
+     * @return The patched persisted entity as a {@link FranchiseDto}.
+     *
+     * @throws javax.persistence.EntityNotFoundException Thrown if the ID provided doesn't match an existing {@link Franchise} entity.
+     * @throws NullPointerException Thrown if the {@link JsonMergePatch} argument is null.
+     */
+    FranchiseDto patch(long id, JsonMergePatch jsonMergePatch);
+
+    /**
+     * Deletes the persisted entity that is mapped to the given ID. If the service cannot find a {@link FranchiseDto} that is mapped to the ID,
+     * then deletion will not occur and a {@link javax.persistence.EntityNotFoundException} exception will be thrown. Deletion can be
+     * classes as successful if the method completes without throwing additional errors.
+     *
+     * @param id The ID of the {@link FranchiseDto} to delete.
+     *
+     * @throws javax.persistence.EntityNotFoundException Thrown if the ID doesn't map to an existing {@link Franchise} entity.
+     */
+    void deleteById(long id);
+}

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/GameService.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/GameService.java
@@ -271,6 +271,29 @@ public interface GameService {
     GameDto updatePublishersForGameId(long id, @NonNull Collection<Long> publisherIds);
 
     /**
+     * Given the ID of a {@link Franchise}, this method will retrieve a {@link Page} of {@link Game}s that are associated with
+     * the given {@link FranchiseDto}. If the ID provided does not map to any {@link FranchiseDto}, a {@link javax.persistence.EntityNotFoundException}
+     * will be thrown. If there are no {@link Game}s associated with the {@link FranchiseDto}, an empty {@link Iterable} will be returned.
+     *
+     * @param franchiseId The ID of the {@link Franchise} to retrieve {@link Game} entries for.
+     * @param pageable The amount of data and the page to return.
+     *
+     * @return A page of {@link GameDto}s that are mapped with the given {@link Franchise} entity.
+     */
+    Iterable<GameDto> findGamesByFranchiseId(long franchiseId, Pageable pageable);
+
+    /**
+     * Given the ID of a {@link Franchise}, this method will retrieve the total count for how many {@link GameDto}'s have an association
+     * to the given {@link Franchise}. If the ID provided does not map to any {@link Franchise}, {@link javax.persistence.EntityNotFoundException}
+     * will be thrown.
+     *
+     * @param franchiseId The ID of the {@link Franchise} to retrieve the total count of {@link Game} entries for.
+     *
+     * @return The total count of {@link GameDto}'s associated with the given {@link Franchise}.
+     */
+    long countGamesByFranchiseId(long franchiseId);
+
+    /**
      * Retrieves all of the {@link Game} entities stored within the persistence layer. This method should not be used within a live
      * environment, as the amount of data may cause buffer overflows and bring down the server. It should only be used within a test
      * environment and even then, with hesitancy.

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/dto/FranchiseDto.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/dto/FranchiseDto.java
@@ -1,0 +1,27 @@
+package com.sparkystudios.traklibrary.game.service.dto;
+
+import lombok.Data;
+import org.springframework.hateoas.server.core.Relation;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+@Data
+@Relation(collectionRelation = "data", itemRelation = "franchise")
+public class FranchiseDto {
+
+    private long id;
+
+    @NotEmpty(message = "{franchise.validation.title.not-empty}")
+    @Size(max = 255, message = "{franchise.validation.title.size}")
+    private String title;
+
+    private String description;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private Long version;
+}

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/dto/GameDetailsDto.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/dto/GameDetailsDto.java
@@ -24,6 +24,8 @@ public class GameDetailsDto {
 
     private LocalDateTime updatedAt;
 
+    private Long franchiseId;
+
     private Long version;
 
     private Set<PlatformDto> platforms = new TreeSet<>();
@@ -33,4 +35,6 @@ public class GameDetailsDto {
     private Set<GenreDto> genres = new TreeSet<>();
 
     private Set<GameReleaseDateDto> releaseDates = new TreeSet<>();
+
+    private FranchiseDto franchise;
 }

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/dto/GameDto.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/dto/GameDto.java
@@ -30,6 +30,8 @@ public class GameDto {
 
     private Set<GameMode> gameModes = EnumSet.noneOf(GameMode.class);
 
+    private Long franchiseId;
+
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/impl/FranchiseServiceImpl.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/impl/FranchiseServiceImpl.java
@@ -1,0 +1,111 @@
+package com.sparkystudios.traklibrary.game.service.impl;
+
+import com.sparkystudios.traklibrary.game.repository.FranchiseRepository;
+import com.sparkystudios.traklibrary.game.repository.specification.FranchiseSpecification;
+import com.sparkystudios.traklibrary.game.service.FranchiseService;
+import com.sparkystudios.traklibrary.game.service.PatchService;
+import com.sparkystudios.traklibrary.game.service.dto.FranchiseDto;
+import com.sparkystudios.traklibrary.game.service.mapper.FranchiseMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.json.JsonMergePatch;
+import javax.persistence.EntityExistsException;
+import javax.persistence.EntityNotFoundException;
+import java.util.Objects;
+
+@RequiredArgsConstructor
+@Service
+public class FranchiseServiceImpl implements FranchiseService {
+
+    private static final String ENTITY_EXISTS_MESSAGE = "franchise.exception.entity-exists";
+    private static final String NOT_FOUND_MESSAGE = "franchise.exception.not-found";
+
+    private final FranchiseRepository franchiseRepository;
+    private final FranchiseMapper franchiseMapper;
+    private final MessageSource messageSource;
+    private final PatchService patchService;
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public FranchiseDto save(FranchiseDto franchiseDto) {
+        Objects.requireNonNull(franchiseDto);
+
+        if (franchiseRepository.existsById(franchiseDto.getId())) {
+            String errorMessage = messageSource
+                    .getMessage(ENTITY_EXISTS_MESSAGE, new Object[] { franchiseDto.getId() }, LocaleContextHolder.getLocale());
+
+            throw new EntityExistsException(errorMessage);
+        }
+
+        return franchiseMapper.franchiseToFranchiseDto(franchiseRepository.save(franchiseMapper.franchiseDtoToFranchise(franchiseDto)));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public FranchiseDto findById(long id) {
+        String errorMessage = messageSource
+                .getMessage(NOT_FOUND_MESSAGE, new Object[] { id }, LocaleContextHolder.getLocale());
+
+        return franchiseMapper.franchiseToFranchiseDto(franchiseRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(errorMessage)));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Iterable<FranchiseDto> findAll(FranchiseSpecification franchiseSpecification, Pageable pageable) {
+        Objects.requireNonNull(pageable);
+
+        return franchiseRepository.findAll(franchiseSpecification, pageable)
+                .map(franchiseMapper::franchiseToFranchiseDto);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long count(FranchiseSpecification franchiseSpecification) {
+        Objects.requireNonNull(franchiseSpecification);
+
+        return franchiseRepository.count(franchiseSpecification);
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public FranchiseDto update(FranchiseDto franchiseDto) {
+        Objects.requireNonNull(franchiseDto);
+
+        if (!franchiseRepository.existsById(franchiseDto.getId())) {
+            String errorMessage = messageSource
+                    .getMessage(NOT_FOUND_MESSAGE, new Object[] { franchiseDto.getId() }, LocaleContextHolder.getLocale());
+
+            throw new EntityNotFoundException(errorMessage);
+        }
+
+        return franchiseMapper.franchiseToFranchiseDto(franchiseRepository.save(franchiseMapper.franchiseDtoToFranchise(franchiseDto)));
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public FranchiseDto patch(long id, JsonMergePatch jsonMergePatch) {
+        // Set the new Java object with the patch information.
+        FranchiseDto patched = patchService.patch(jsonMergePatch, findById(id), FranchiseDto.class);
+        // Save to the repository and convert it back to a GameDto.
+        return franchiseMapper.franchiseToFranchiseDto(franchiseRepository.save(franchiseMapper.franchiseDtoToFranchise(patched)));
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void deleteById(long id) {
+        if (!franchiseRepository.existsById(id)) {
+            String errorMessage = messageSource
+                    .getMessage(NOT_FOUND_MESSAGE, new Object[] { id }, LocaleContextHolder.getLocale());
+
+            throw new EntityNotFoundException(errorMessage);
+        }
+
+        franchiseRepository.deleteById(id);
+    }
+}

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/impl/GameServiceImpl.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/impl/GameServiceImpl.java
@@ -32,6 +32,7 @@ public class GameServiceImpl implements GameService {
     private static final String GENRE_NOT_FOUND_MESSAGE = "genre.exception.not-found";
     private static final String PLATFORM_NOT_FOUND_MESSAGE = "platform.exception.not-found";
     private static final String DEVELOPER_NOT_FOUND_MESSAGE = "developer.exception.not-found";
+    private static final String FRANCHISE_NOT_FOUND_MESSAGE = "franchise.exception.not-found";
     private static final String PUBLISHER_NOT_FOUND_MESSAGE = "publisher.exception.not-found";
 
     private final GameRepository gameRepository;
@@ -39,6 +40,7 @@ public class GameServiceImpl implements GameService {
     private final PlatformRepository platformRepository;
     private final DeveloperRepository developerRepository;
     private final PublisherRepository publisherRepository;
+    private final FranchiseRepository franchiseRepository;
     private final GameMapper gameMapper;
     private final MessageSource messageSource;
     private final PatchService patchService;
@@ -343,6 +345,31 @@ public class GameServiceImpl implements GameService {
 
         // Save the game and return the result.
         return gameMapper.gameToGameDto(gameRepository.save(game));
+    }
+
+    @Override
+    public Iterable<GameDto> findGamesByFranchiseId(long franchiseId, Pageable pageable) {
+        if (!franchiseRepository.existsById(franchiseId)) {
+            String errorMessage = messageSource
+                    .getMessage(FRANCHISE_NOT_FOUND_MESSAGE, new Object[] { franchiseId }, LocaleContextHolder.getLocale());
+
+            throw new EntityNotFoundException((errorMessage));
+        }
+
+        return gameRepository.findByFranchiseId(franchiseId, pageable)
+                .map(gameMapper::gameToGameDto);
+    }
+
+    @Override
+    public long countGamesByFranchiseId(long franchiseId) {
+        if (!franchiseRepository.existsById(franchiseId)) {
+            String errorMessage = messageSource
+                    .getMessage(FRANCHISE_NOT_FOUND_MESSAGE, new Object[] { franchiseId }, LocaleContextHolder.getLocale());
+
+            throw new EntityNotFoundException((errorMessage));
+        }
+
+        return gameRepository.countByFranchiseId(franchiseId);
     }
 
     @Override

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/mapper/FranchiseMapper.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/mapper/FranchiseMapper.java
@@ -1,0 +1,16 @@
+package com.sparkystudios.traklibrary.game.service.mapper;
+
+import com.sparkystudios.traklibrary.game.domain.Franchise;
+import com.sparkystudios.traklibrary.game.service.dto.FranchiseDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface FranchiseMapper {
+
+    FranchiseDto franchiseToFranchiseDto(Franchise franchise);
+
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    Franchise franchiseDtoToFranchise(FranchiseDto franchiseDto);
+}

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/mapper/GameDetailsMapper.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/mapper/GameDetailsMapper.java
@@ -24,4 +24,8 @@ public interface GameDetailsMapper {
     default GameReleaseDateDto gameReleaseDateToGameReleaseDateDto(GameReleaseDate gameReleaseDate) {
         return GameMappers.GAME_RELEASE_DATE_MAPPER.gameReleaseDateToGameReleaseDateDto(gameReleaseDate);
     }
+
+    default FranchiseDto franchiseToFranchiseDto(Franchise franchise) {
+        return GameMappers.FRANCHISE_MAPPER.franchiseToFranchiseDto(franchise);
+    }
 }

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/mapper/GameMappers.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/mapper/GameMappers.java
@@ -9,6 +9,8 @@ public final class GameMappers {
 
     public static final DeveloperMapper DEVELOPER_MAPPER = Mappers.getMapper(DeveloperMapper.class);
 
+    public static final FranchiseMapper FRANCHISE_MAPPER = Mappers.getMapper(FranchiseMapper.class);
+
     public static final GameBarcodeMapper GAME_BARCODE_MAPPER = Mappers.getMapper(GameBarcodeMapper.class);
 
     public static final GameDetailsMapper GAME_INFO_MAPPER = Mappers.getMapper(GameDetailsMapper.class);

--- a/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/impl/FranchiseServiceImplTest.java
+++ b/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/impl/FranchiseServiceImplTest.java
@@ -1,0 +1,285 @@
+package com.sparkystudios.traklibrary.game.service.impl;
+
+import com.sparkystudios.traklibrary.game.domain.Franchise;
+import com.sparkystudios.traklibrary.game.repository.FranchiseRepository;
+import com.sparkystudios.traklibrary.game.repository.specification.FranchiseSpecification;
+import com.sparkystudios.traklibrary.game.service.PatchService;
+import com.sparkystudios.traklibrary.game.service.dto.FranchiseDto;
+import com.sparkystudios.traklibrary.game.service.mapper.FranchiseMapper;
+import com.sparkystudios.traklibrary.game.service.mapper.GameMappers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.MessageSource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import javax.json.JsonMergePatch;
+import javax.persistence.EntityExistsException;
+import javax.persistence.EntityNotFoundException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+@ExtendWith(MockitoExtension.class)
+class FranchiseServiceImplTest {
+
+    @Mock
+    private FranchiseRepository franchiseRepository;
+
+    @Spy
+    private final FranchiseMapper franchiseMapper = GameMappers.FRANCHISE_MAPPER;
+
+    @Mock
+    private MessageSource messageSource;
+
+    @Mock
+    private PatchService patchService;
+
+    @InjectMocks
+    private FranchiseServiceImpl franchiseService;
+
+    @Test
+    void save_withNullFranchiseDto_throwsNullPointerException() {
+        // Assert
+        Assertions.assertThrows(NullPointerException.class, () -> franchiseService.save(null));
+    }
+
+    @Test
+    void save_withExistingEntity_throwsEntityExistsException() {
+        // Arrange
+        Mockito.when(franchiseRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(true);
+
+        Mockito.when(messageSource.getMessage(ArgumentMatchers.anyString(), ArgumentMatchers.any(Object[].class), ArgumentMatchers.any(Locale.class)))
+                .thenReturn("");
+
+        FranchiseDto franchiseDto = new FranchiseDto();
+
+        // Assert
+        Assertions.assertThrows(EntityExistsException.class, () -> franchiseService.save(franchiseDto));
+    }
+
+    @Test
+    void save_withNewFranchiseDto_savesFranchiseDto() {
+        // Arrange
+        Mockito.when(franchiseRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(false);
+
+        Mockito.when(franchiseRepository.save(ArgumentMatchers.any()))
+                .thenReturn(new Franchise());
+
+        // Act
+        franchiseService.save(new FranchiseDto());
+
+        // Assert
+        Mockito.verify(franchiseRepository, Mockito.atMostOnce())
+                .save(ArgumentMatchers.any());
+    }
+
+    @Test
+    void findById_withEmptyOptional_throwsEntityNotFoundException() {
+        // Arrange
+        Mockito.when(messageSource.getMessage(ArgumentMatchers.anyString(), ArgumentMatchers.any(Object[].class), ArgumentMatchers.any(Locale.class)))
+                .thenReturn("");
+
+        Mockito.when(franchiseRepository.findById(ArgumentMatchers.anyLong()))
+                .thenReturn(Optional.empty());
+
+        // Assert
+        Assertions.assertThrows(EntityNotFoundException.class, () -> franchiseService.findById(0L));
+    }
+
+    @Test
+    void findById_withValidFranchise_returnsFranchiseDto() {
+        // Arrange
+        Franchise franchise = new Franchise();
+        franchise.setId(1L);
+        franchise.setTitle("test-title");
+        franchise.setDescription("test-description");
+        franchise.setVersion(1L);
+
+        Mockito.when(messageSource.getMessage(ArgumentMatchers.anyString(), ArgumentMatchers.any(Object[].class), ArgumentMatchers.any(Locale.class)))
+                .thenReturn("");
+
+        Mockito.when(franchiseRepository.findById(ArgumentMatchers.anyLong()))
+                .thenReturn(Optional.of(franchise));
+
+        // Act
+        FranchiseDto result = franchiseService.findById(0L);
+
+        // Assert
+        Assertions.assertNotNull(result, "The mapped result should not be null.");
+    }
+
+    @Test
+    void findAll_withNullPageable_throwsNullPointerException() {
+        // Arrange
+        FranchiseSpecification franchiseSpecification = Mockito.mock(FranchiseSpecification.class);
+
+        // Assert
+        Assertions.assertThrows(NullPointerException.class, () -> franchiseService.findAll(franchiseSpecification, null));
+    }
+
+    @Test
+    void findAll_withNoFranchises_returnsEmptyList() {
+        // Arrange
+        Mockito.when(franchiseRepository.findAll(ArgumentMatchers.any(FranchiseSpecification.class), ArgumentMatchers.any(Pageable.class)))
+                .thenReturn(Page.empty());
+
+        FranchiseSpecification franchiseSpecification = Mockito.mock(FranchiseSpecification.class);
+        Pageable pageable = Mockito.mock(Pageable.class);
+
+        // Act
+        List<FranchiseDto> result = StreamSupport.stream(franchiseService.findAll(franchiseSpecification, pageable).spliterator(), false)
+                .collect(Collectors.toList());
+
+        // Assert
+        Assertions.assertTrue(result.isEmpty(), "The result should be empty if no paged franchise results were found.");
+    }
+
+    @Test
+    void findAll_withFranchises_returnsFranchisesAsFranchiseDtos() {
+        // Arrange
+        Page<Franchise> franchises = new PageImpl<>(Arrays.asList(new Franchise(), new Franchise()));
+
+        Mockito.when(franchiseRepository.findAll(ArgumentMatchers.any(FranchiseSpecification.class), ArgumentMatchers.any(Pageable.class)))
+                .thenReturn(franchises);
+
+        FranchiseSpecification franchiseSpecification = Mockito.mock(FranchiseSpecification.class);
+        Pageable pageable = Mockito.mock(Pageable.class);
+
+        // Act
+        List<FranchiseDto> result = StreamSupport.stream(franchiseService.findAll(franchiseSpecification, pageable).spliterator(), false)
+                .collect(Collectors.toList());
+
+        // Assert
+        Assertions.assertFalse(result.isEmpty(), "The result shouldn't be empty if the repository returned franchises.");
+    }
+
+    @Test
+    void count_withNullFranchiseSpecification_throwsNullPointerException() {
+        // Assert
+        Assertions.assertThrows(NullPointerException.class, () -> franchiseService.count(null));
+    }
+
+    @Test
+    void count_withValidGameUserEntrySpecification_invokesCount() {
+        // Arrange
+        Mockito.when(franchiseRepository.count(ArgumentMatchers.any()))
+                .thenReturn(0L);
+
+        // Act
+        franchiseService.count(Mockito.mock(FranchiseSpecification.class));
+
+        // Assert
+        Mockito.verify(franchiseRepository, Mockito.atMostOnce())
+                .count(Mockito.any());
+    }
+
+    @Test
+    void update_withNullFranchiseDto_throwsNullPointerException() {
+        // Assert
+        Assertions.assertThrows(NullPointerException.class, () -> franchiseService.update(null));
+    }
+
+    @Test
+    void update_withNonExistentEntity_throwsEntityNotFoundException() {
+        // Arrange
+        Mockito.when(franchiseRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(false);
+
+        Mockito.when(messageSource.getMessage(ArgumentMatchers.anyString(), ArgumentMatchers.any(Object[].class), ArgumentMatchers.any(Locale.class)))
+                .thenReturn("");
+
+        FranchiseDto franchiseDto = new FranchiseDto();
+
+        // Assert
+        Assertions.assertThrows(EntityNotFoundException.class, () -> franchiseService.update(franchiseDto));
+    }
+
+    @Test
+    void update_withExistingFranchiseDto_updatesFranchiseDto() {
+        // Arrange
+        Mockito.when(franchiseRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(true);
+
+        Mockito.when(franchiseRepository.save(ArgumentMatchers.any()))
+                .thenReturn(new Franchise());
+
+        // Act
+        franchiseService.update(new FranchiseDto());
+
+        // Assert
+        Mockito.verify(franchiseRepository, Mockito.atMostOnce())
+                .save(ArgumentMatchers.any());
+    }
+
+    @Test
+    void patch_withNoFranchiseMatchingId_throwsEntityNotFoundException() {
+        // Arrange
+        Mockito.when(franchiseRepository.findById(ArgumentMatchers.anyLong()))
+                .thenReturn(Optional.empty());
+
+        Mockito.when(messageSource.getMessage(ArgumentMatchers.anyString(), ArgumentMatchers.any(Object[].class), ArgumentMatchers.any(Locale.class)))
+                .thenReturn("");
+
+        JsonMergePatch jsonMergePatch = Mockito.mock(JsonMergePatch.class);
+
+        // Assert
+        Assertions.assertThrows(EntityNotFoundException.class, () -> franchiseService.patch(0L, jsonMergePatch));
+    }
+
+    @Test
+    void patch_withValidId_saveFranchise() {
+        // Arrange
+        Mockito.when(franchiseRepository.findById(ArgumentMatchers.anyLong()))
+                .thenReturn(Optional.of(new Franchise()));
+
+        Mockito.when(messageSource.getMessage(ArgumentMatchers.anyString(), ArgumentMatchers.any(Object[].class), ArgumentMatchers.any(Locale.class)))
+                .thenReturn("");
+
+        Mockito.when(patchService.patch(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any()))
+                .thenReturn(new FranchiseDto());
+
+        // Act
+        franchiseService.patch(0L, Mockito.mock(JsonMergePatch.class));
+
+        // Assert
+        Mockito.verify(franchiseRepository, Mockito.atMostOnce())
+                .save(ArgumentMatchers.any());
+    }
+
+    @Test
+    void delete_withNonExistentId_throwsEntityNotFoundException() {
+        // Arrange
+        Mockito.when(franchiseRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(false);
+
+        // Assert
+        Assertions.assertThrows(EntityNotFoundException.class, () -> franchiseService.deleteById(0L));
+    }
+
+    @Test
+    void delete_withExistingId_invokesDeletion() {
+        // Arrange
+        Mockito.when(franchiseRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(true);
+
+        Mockito.doNothing().when(franchiseRepository)
+                .deleteById(ArgumentMatchers.anyLong());
+
+        // Act
+        franchiseService.deleteById(0L);
+
+        // Assert
+        Mockito.verify(franchiseRepository, Mockito.atMostOnce())
+                .deleteById(ArgumentMatchers.anyLong());
+    }
+}

--- a/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/mapper/FranchiseMapperTest.java
+++ b/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/mapper/FranchiseMapperTest.java
@@ -1,0 +1,75 @@
+package com.sparkystudios.traklibrary.game.service.mapper;
+
+import com.sparkystudios.traklibrary.game.domain.Franchise;
+import com.sparkystudios.traklibrary.game.service.dto.FranchiseDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+class FranchiseMapperTest {
+
+    @Test
+    void franchiseToFranchiseDto_withNull_returnsNull() {
+        // Act
+        FranchiseDto result = GameMappers.FRANCHISE_MAPPER.franchiseToFranchiseDto(null);
+
+        // Assert
+        Assertions.assertThat(result).isNull();
+    }
+
+    @Test
+    void franchiseToFranchiseDto_withFranchise_mapsFields() {
+        // Arrange
+        Franchise franchise = new Franchise();
+        franchise.setId(5L);
+        franchise.setTitle("test-title");
+        franchise.setDescription("test-description");
+        franchise.setCreatedAt(LocalDateTime.now());
+        franchise.setUpdatedAt(LocalDateTime.now());
+        franchise.setVersion(1L);
+
+        // Act
+        FranchiseDto result = GameMappers.FRANCHISE_MAPPER.franchiseToFranchiseDto(franchise);
+
+        // Assert
+        Assertions.assertThat(result.getId()).isEqualTo(franchise.getId());
+        Assertions.assertThat(result.getTitle()).isEqualTo(franchise.getTitle());
+        Assertions.assertThat(result.getDescription()).isEqualTo(franchise.getDescription());
+        Assertions.assertThat(result.getCreatedAt()).isEqualTo(franchise.getCreatedAt());
+        Assertions.assertThat(result.getUpdatedAt()).isEqualTo(franchise.getUpdatedAt());
+        Assertions.assertThat(result.getVersion()).isEqualTo(franchise.getVersion());
+    }
+
+    @Test
+    void franchiseDtoToFranchise_withNull_returnsNull() {
+        // Act
+        Franchise result = GameMappers.FRANCHISE_MAPPER.franchiseDtoToFranchise(null);
+
+        // Assert
+        Assertions.assertThat(result).isNull();
+    }
+
+    @Test
+    void franchiseDtoToFranchise_withFranchiseDto_mapsFields() {
+        // Arrange
+        FranchiseDto franchiseDto = new FranchiseDto();
+        franchiseDto.setId(5L);
+        franchiseDto.setTitle("test-title");
+        franchiseDto.setDescription("test-description");
+        franchiseDto.setCreatedAt(LocalDateTime.now());
+        franchiseDto.setUpdatedAt(LocalDateTime.now());
+        franchiseDto.setVersion(1L);
+
+        // Act
+        Franchise result = GameMappers.FRANCHISE_MAPPER.franchiseDtoToFranchise(franchiseDto);
+
+        // Assert
+        Assertions.assertThat(result.getId()).isEqualTo(franchiseDto.getId());
+        Assertions.assertThat(result.getTitle()).isEqualTo(franchiseDto.getTitle());
+        Assertions.assertThat(result.getDescription()).isEqualTo(franchiseDto.getDescription());
+        Assertions.assertThat(result.getCreatedAt()).isNull();
+        Assertions.assertThat(result.getUpdatedAt()).isNull();
+        Assertions.assertThat(result.getVersion()).isEqualTo(franchiseDto.getVersion());
+    }
+}

--- a/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/mapper/GameDetailsMapperTest.java
+++ b/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/mapper/GameDetailsMapperTest.java
@@ -35,16 +35,21 @@ class GameDetailsMapperTest {
         gameReleaseDate.setReleaseDate(LocalDate.now());
         gameReleaseDate.setVersion(1L);
 
+        Franchise franchise = new Franchise();
+        franchise.setTitle("franchise-title");
+
         Game game = new Game();
         game.setId(5L);
         game.setTitle("test-title");
         game.setDescription("sure is a description.");
         game.setAgeRating(AgeRating.TEEN);
+        game.setFranchiseId(5L);
         game.setVersion(5L);
         game.addGenre(genre);
         game.addPlatform(platform);
         game.addPublisher(publisher);
         game.addReleaseDate(gameReleaseDate);
+        game.setFranchise(franchise);
 
         // Act
         GameDetailsDto result = GameMappers.GAME_INFO_MAPPER.gameToGameDetailsDto(game);
@@ -54,10 +59,12 @@ class GameDetailsMapperTest {
         Assertions.assertThat(result.getTitle()).isEqualTo(game.getTitle());
         Assertions.assertThat(result.getDescription()).isEqualTo(game.getDescription());
         Assertions.assertThat(result.getAgeRating()).isEqualTo(game.getAgeRating());
+        Assertions.assertThat(result.getFranchiseId()).isEqualTo(game.getFranchiseId());
         Assertions.assertThat(result.getVersion()).isEqualTo(game.getVersion());
         Assertions.assertThat(result.getGenres()).hasSize(1);
         Assertions.assertThat(result.getPlatforms()).hasSize(1);
         Assertions.assertThat(result.getPublishers()).hasSize(1);
         Assertions.assertThat(result.getReleaseDates()).hasSize(1);
+        Assertions.assertThat(result.getFranchise().getTitle()).isEqualTo(franchise.getTitle());
     }
 }

--- a/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/mapper/GameMapperTest.java
+++ b/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/mapper/GameMapperTest.java
@@ -34,6 +34,7 @@ class GameMapperTest {
         game.setDescription("test-description");
         game.setAgeRating(AgeRating.ADULTS_ONLY);
         game.getGameModes().add(GameMode.MULTI_PLAYER);
+        game.setFranchiseId(5L);
         game.setCreatedAt(LocalDateTime.now());
         game.setUpdatedAt(LocalDateTime.now());
         game.setVersion(1L);
@@ -48,6 +49,7 @@ class GameMapperTest {
         Assertions.assertThat(result.getDescription()).isEqualTo(game.getDescription());
         Assertions.assertThat(result.getAgeRating()).isEqualTo(game.getAgeRating());
         Assertions.assertThat(result.getGameModes()).isEqualTo(game.getGameModes());
+        Assertions.assertThat(result.getFranchiseId()).isEqualTo(game.getFranchiseId());
         Assertions.assertThat(result.getCreatedAt()).isEqualTo(game.getCreatedAt());
         Assertions.assertThat(result.getUpdatedAt()).isEqualTo(game.getUpdatedAt());
         Assertions.assertThat(result.getVersion()).isEqualTo(game.getVersion());
@@ -77,6 +79,7 @@ class GameMapperTest {
         gameDto.setDescription("test-description");
         gameDto.setAgeRating(AgeRating.EVERYONE_TEN_PLUS);
         gameDto.getGameModes().add(GameMode.MULTI_PLAYER);
+        gameDto.setFranchiseId(5L);
         gameDto.setCreatedAt(LocalDateTime.now());
         gameDto.setUpdatedAt(LocalDateTime.now());
         gameDto.setVersion(1L);
@@ -91,6 +94,7 @@ class GameMapperTest {
         Assertions.assertThat(result.getDescription()).isEqualTo(gameDto.getDescription());
         Assertions.assertThat(result.getAgeRating()).isEqualTo(gameDto.getAgeRating());
         Assertions.assertThat(result.getGameModes()).isEqualTo(gameDto.getGameModes());
+        Assertions.assertThat(result.getFranchiseId()).isEqualTo(gameDto.getFranchiseId());
         Assertions.assertThat(result.getCreatedAt()).isNull();
         Assertions.assertThat(result.getUpdatedAt()).isNull();
         Assertions.assertThat(result.getVersion()).isEqualTo(gameDto.getVersion());

--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -53,8 +53,8 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/gateway-server/src/main/java/com/sparkystudios/traklibrary/gateway/server/config/SecurityConfig.java
+++ b/gateway-server/src/main/java/com/sparkystudios/traklibrary/gateway/server/config/SecurityConfig.java
@@ -38,13 +38,13 @@ public class SecurityConfig {
         protected void configure(HttpSecurity http) throws Exception {
             http
                     .requestMatchers()
-                    .antMatchers("/api/auth/**", "/api/games/**", "/api/images/**", "/api/notifications/**")
+                    .antMatchers("/auth/**", "/games/**", "/images/**", "/notifications/**")
                     .and()
                     .authorizeRequests()
-                    .antMatchers(HttpMethod.POST, "/api/auth", "/api/auth/users").permitAll()
-                    .antMatchers(HttpMethod.PUT, "/api/auth/users", "/api/auth/users/recover").permitAll()
-                    .antMatchers(HttpMethod.GET, "/api/images/**").permitAll()
-                    .antMatchers(HttpMethod.GET, "/api/games/**/image").permitAll()
+                    .antMatchers(HttpMethod.POST, "/auth", "/auth/users").permitAll()
+                    .antMatchers(HttpMethod.PUT, "/auth/users", "/auth/users/recover").permitAll()
+                    .antMatchers(HttpMethod.GET, "/images/**").permitAll()
+                    .antMatchers(HttpMethod.GET, "/games/**/image").permitAll()
                     .anyRequest()
                     .authenticated()
                     .and()
@@ -78,7 +78,7 @@ public class SecurityConfig {
         @Override
         protected void configure(HttpSecurity http) throws Exception {
             http
-                    .antMatcher("/api/emails/**")
+                    .antMatcher("/emails/**")
                     .authorizeRequests()
                     .anyRequest()
                     .authenticated()

--- a/image-server/pom.xml
+++ b/image-server/pom.xml
@@ -55,8 +55,8 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/notification-server/pom.xml
+++ b/notification-server/pom.xml
@@ -50,8 +50,8 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
                             </configuration>
                         </plugin>
                         <plugin>
-                            <groupId>com.spotify</groupId>
-                            <artifactId>dockerfile-maven-plugin</artifactId>
+                            <groupId>io.fabric8</groupId>
+                            <artifactId>docker-maven-plugin</artifactId>
                             <executions>
                                 <execution>
                                     <id>default</id>
@@ -46,9 +46,13 @@
                                 </execution>
                             </executions>
                             <configuration>
-                                <repository>sparkystudios/${project.build.finalName}</repository>
+                                <images>
+                                    <image>
+                                        <name>sparkystudios/${project.build.finalName}</name>
+                                    </image>
+                                </images>
                                 <buildArgs>
-                                    <DEBUG_ARGS>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005</DEBUG_ARGS>
+                                    <DEBUG_ARGS>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005</DEBUG_ARGS>
                                 </buildArgs>
                             </configuration>
                         </plugin>
@@ -84,8 +88,8 @@
                             </executions>
                         </plugin>
                         <plugin>
-                            <groupId>com.spotify</groupId>
-                            <artifactId>dockerfile-maven-plugin</artifactId>
+                            <groupId>io.fabric8</groupId>
+                            <artifactId>docker-maven-plugin</artifactId>
                             <executions>
                                 <execution>
                                     <id>default</id>
@@ -96,8 +100,21 @@
                                 </execution>
                             </executions>
                             <configuration>
-                                <repository>sparkystudios/${project.build.finalName}</repository>
-                                <tag>${project.version}</tag>
+                                <pushRegistry>sparkystudios/${project.build.finalName}</pushRegistry>
+                                <images>
+                                    <image>
+                                        <name>sparkystudios/${project.build.finalName}</name>
+                                        <build>
+                                            <contextDir>${project.basedir}</contextDir>
+                                            <tags>
+                                                <tag>${project.version}</tag>
+                                            </tags>
+                                        </build>
+                                    </image>
+                                </images>
+                                <buildArgs>
+                                    <DEBUG_ARGS>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005</DEBUG_ARGS>
+                                </buildArgs>
                             </configuration>
                         </plugin>
                     </plugins>
@@ -130,23 +147,6 @@
                                     </goals>
                                 </execution>
                             </executions>
-                        </plugin>
-                        <plugin>
-                            <groupId>com.spotify</groupId>
-                            <artifactId>dockerfile-maven-plugin</artifactId>
-                            <executions>
-                                <execution>
-                                    <id>default</id>
-                                    <phase>package</phase>
-                                    <goals>
-                                        <goal>build</goal>
-                                    </goals>
-                                </execution>
-                            </executions>
-                            <configuration>
-                                <repository>sparkystudios/${project.build.finalName}</repository>
-                                <tag>${project.version}</tag>
-                            </configuration>
                         </plugin>
                     </plugins>
                 </pluginManagement>
@@ -196,11 +196,13 @@
         <!-- Other version -->
         <com.github.faker.version>1.0.2</com.github.faker.version>
         <com.google.guava.version>29.0-jre</com.google.guava.version>
+        <io.fabric8.version>0.33.0</io.fabric8.version>
         <io.jsonwebtoken.version>0.9.1</io.jsonwebtoken.version>
         <javax.json.version>1.1.4</javax.json.version>
         <javax.validation.version>2.0.0.Final</javax.validation.version>
         <net.kaczmarzyk.specification.version>2.1.1</net.kaczmarzyk.specification.version>
         <org.apache.httpcomponents.version>4.5.3</org.apache.httpcomponents.version>
+        <org.apache.maven.plugins.version>3.8.1</org.apache.maven.plugins.version>
         <org.assertj.version>3.16.1</org.assertj.version>
         <org.jacoco.version>0.8.5</org.jacoco.version>
         <org.glassfish.javax.json.version>1.1.4</org.glassfish.javax.json.version>
@@ -361,7 +363,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>${org.apache.maven.plugins.version}</version>
                 <configuration>
                     <source>11</source>
                     <target>11</target>
@@ -461,9 +463,9 @@
                     <artifactId>spring-boot-maven-plugin</artifactId>
                 </plugin>
                 <plugin>
-                    <groupId>com.spotify</groupId>
-                    <artifactId>dockerfile-maven-plugin</artifactId>
-                    <version>1.4.10</version>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>${io.fabric8.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
- Added a new franchise entity, along with subsequent DTO, mapper, repository, service and controller.
- Added a reference to the franchise within the game, with a many-to-one relationship.
- Added a new table within the liquibase script for the franchise.
- Changed docker plugin from spotify to fabric8 due to some teething issues.
- Ensured versions for maven dependencies are stored as properties.
- Added tests for new functionality and classes.
- Removed docker references from the staging buildspec, to spin off for a new issue.
- Removed the /api from all of the endpoints, as the eventual endpoint for production Trak API will be https://api.traklibrary.com.