### PR TITLE
APP-30: Added support for DLC

### DIFF
--- a/auth-server/src/main/resources/i18n/validation.properties
+++ b/auth-server/src/main/resources/i18n/validation.properties
@@ -12,4 +12,5 @@ recovery-request.validation.password.invalid=The password does not match the pas
 
 registration-request.validation.username.not-empty=The username cannot be empty or null.
 registration-request.validation.email-address.invalid=The email address is invalid.
+registration-request.validation.email-address.not-empty=The email address cannot be empty or null.
 registration-request.validation.password.invalid=The password does not match the password criteria.

--- a/auth-server/src/main/resources/i18n/validation_en.properties
+++ b/auth-server/src/main/resources/i18n/validation_en.properties
@@ -12,4 +12,5 @@ recovery-request.validation.password.invalid=The password does not match the pas
 
 registration-request.validation.username.not-empty=The username cannot be empty or null.
 registration-request.validation.email-address.invalid=The email address is invalid.
+registration-request.validation.email-address.not-empty=The email address cannot be empty or null.
 registration-request.validation.password.invalid=The password does not match the password criteria.

--- a/auth-service/src/main/java/com/sparkystudios/traklibrary/authentication/service/dto/RegistrationRequestDto.java
+++ b/auth-service/src/main/java/com/sparkystudios/traklibrary/authentication/service/dto/RegistrationRequestDto.java
@@ -22,6 +22,7 @@ public class RegistrationRequestDto {
     @NotEmpty(message = "{registration-request.validation.username.not-empty}")
     private String username;
 
+    @NotEmpty(message = "{registration-request.validation.email-address.not-empty}")
     @Email(message = "{registration-request.validation.email-address.invalid}")
     private String emailAddress;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: "3.3"
 services:
   auth-server:
-    container_name: traklibrary-auth-server
-    image: sparkystudios/traklibrary-auth-server:${VERSION}
+    container_name: traklibrary-auth-api
+    image: sparkystudios/traklibrary-auth-api:${VERSION}
     command: ["-m", "512m", "-XX:MinRAMPercentage=50", "-XX:MaxRAMPercentage=80"]
     environment:
       - encrypt.key=${CONFIG_SERVER_ENCRYPT_KEY}
@@ -21,8 +21,8 @@ services:
       - trak-network
 
   config-server:
-    container_name: traklibrary-config-server
-    image: sparkystudios/traklibrary-config-server:${VERSION}
+    container_name: traklibrary-config-api
+    image: sparkystudios/traklibrary-config-api:${VERSION}
     command: ["-m", "512m", "-XX:MinRAMPercentage=50", "-XX:MaxRAMPercentage=80"]
     environment:
       - encrypt.key=${CONFIG_SERVER_ENCRYPT_KEY}
@@ -41,8 +41,8 @@ services:
       - trak-network
 
   discovery-server:
-    container_name: traklibrary-discovery-server
-    image: sparkystudios/traklibrary-discovery-server:${VERSION}
+    container_name: traklibrary-discovery-api
+    image: sparkystudios/traklibrary-discovery-api:${VERSION}
     command: ["-m", "512m", "-XX:MinRAMPercentage=50", "-XX:MaxRAMPercentage=80"]
     environment:
       - spring.security.user.name=${DISCOVERY_SERVER_USERNAME}
@@ -53,8 +53,8 @@ services:
       - trak-network
 
   email-server:
-    container_name: traklibrary-email-server
-    image: sparkystudios/traklibrary-email-server:${VERSION}
+    container_name: traklibrary-email-api
+    image: sparkystudios/traklibrary-email-api:${VERSION}
     command: ["-m", "512m", "-XX:MinRAMPercentage=50", "-XX:MaxRAMPercentage=80"]
     environment:
       - encrypt.key=${CONFIG_SERVER_ENCRYPT_KEY}
@@ -73,8 +73,8 @@ services:
       - trak-network
 
   game-server:
-    container_name: traklibrary-game-server
-    image: sparkystudios/traklibrary-game-server:${VERSION}
+    container_name: traklibrary-game-api
+    image: sparkystudios/traklibrary-game-api:${VERSION}
     command: ["-m", "512m", "-XX:MinRAMPercentage=50", "-XX:MaxRAMPercentage=80"]
     environment:
       - encrypt.key=${CONFIG_SERVER_ENCRYPT_KEY}
@@ -93,8 +93,8 @@ services:
       - trak-network
 
   gateway-server:
-    container_name: traklibrary-gateway-server
-    image: sparkystudios/traklibrary-gateway-server:${VERSION}
+    container_name: traklibrary-gateway-api
+    image: sparkystudios/traklibrary-gateway-api:${VERSION}
     command: ["-m", "512m", "-XX:MinRAMPercentage=50", "-XX:MaxRAMPercentage=80"]
     environment:
       - encrypt.key=${CONFIG_SERVER_ENCRYPT_KEY}
@@ -115,8 +115,8 @@ services:
       - trak-network
 
   image-server:
-    container_name: traklibrary-image-server
-    image: sparkystudios/traklibrary-image-server:${VERSION}
+    container_name: traklibrary-image-api
+    image: sparkystudios/traklibrary-image-api:${VERSION}
     command: ["-m", "512m", "-XX:MinRAMPercentage=50", "-XX:MaxRAMPercentage=80"]
     environment:
       - encrypt.key=${CONFIG_SERVER_ENCRYPT_KEY}
@@ -135,8 +135,8 @@ services:
       - trak-network
 
   notification-server:
-    container_name: traklibrary-notification-server
-    image: sparkystudios/traklibrary-notification-server:${VERSION}
+    container_name: traklibrary-notification-api
+    image: sparkystudios/traklibrary-notification-api:${VERSION}
     command: ["-m", "512m", "-XX:MinRAMPercentage=50", "-XX:MaxRAMPercentage=80"]
     environment:
       - encrypt.key=${CONFIG_SERVER_ENCRYPT_KEY}

--- a/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/DownloadableContent.java
+++ b/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/DownloadableContent.java
@@ -1,0 +1,87 @@
+package com.sparkystudios.traklibrary.game.domain;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ComparisonChain;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Version;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "dlc")
+public class DownloadableContent implements Comparable<DownloadableContent> {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", unique = true, nullable = false, updatable = false)
+    private long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "description", nullable = false, length = 4096)
+    private String description;
+
+    @Column(name = "release_date")
+    private LocalDate releaseDate;
+
+    @Column(name = "game_id", nullable = false, insertable = false, updatable = false)
+    private long gameId;
+
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_id", nullable = false)
+    private Game game;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Version
+    @Column(name = "op_lock_version")
+    private Long version;
+
+    /**
+     * Used for comparison between two {@link DownloadableContent} objects. It's used
+     * internally whenever a {@link DownloadableContent} is the type within a list which
+     * supported inserted sort, such as a {@link java.util.TreeSet}.
+     *
+     * The order in which {@link DownloadableContent} instances are sorted are by {@link DownloadableContent#name}
+     * and then {@link DownloadableContent#id}.
+     *
+     * @param other The other {@link DownloadableContent} instance to compare against.
+     *
+     * @return  a negative integer, zero, or a positive integer as this {@link DownloadableContent}
+     *          is less than, equal to, or greater than the specified object.
+     */
+    @Override
+    public int compareTo(DownloadableContent other) {
+        return ComparisonChain.start()
+                .compare(Strings.nullToEmpty(name), Strings.nullToEmpty(other.name))
+                .compare(id, other.id)
+                .result();
+    }
+}

--- a/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/DownloadableContent.java
+++ b/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/DownloadableContent.java
@@ -34,6 +34,12 @@ public class DownloadableContent implements Comparable<DownloadableContent> {
     @Column(name = "id", unique = true, nullable = false, updatable = false)
     private long id;
 
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_id")
+    private Game game;
+
     @Column(name = "name", nullable = false)
     private String name;
 
@@ -42,15 +48,6 @@ public class DownloadableContent implements Comparable<DownloadableContent> {
 
     @Column(name = "release_date")
     private LocalDate releaseDate;
-
-    @Column(name = "game_id", nullable = false, insertable = false, updatable = false)
-    private long gameId;
-
-    @EqualsAndHashCode.Exclude
-    @ToString.Exclude
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "game_id", nullable = false)
-    private Game game;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreatedDate

--- a/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/Game.java
+++ b/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/Game.java
@@ -92,6 +92,11 @@ public class Game {
     @JoinColumn(name = "franchise_id", insertable = false, updatable = false)
     private Franchise franchise;
 
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    @OneToMany(mappedBy = "game", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    private Set<DownloadableContent> downloadableContents = new TreeSet<>();
+
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreatedDate
     private LocalDateTime createdAt;
@@ -232,5 +237,31 @@ public class Game {
     public void removeReleaseDate(GameReleaseDate gameReleaseDate) {
         releaseDates.remove(gameReleaseDate);
         gameReleaseDate.setGame(null);
+    }
+
+    /**
+     * Convenience method that is used to add a {@link DownloadableContent} to the {@link Game}. As
+     * the relationship between the {@link Game} and {@link DownloadableContent} is bi-directional,
+     * it needs to be added and associated with on both sides of the relationship, which
+     * this method achieved.
+     *
+     * @param downloadableContent The {@link DownloadableContent} to add to the {@link Game}.
+     */
+    public void addDownloadableContent(DownloadableContent downloadableContent) {
+        downloadableContents.add(downloadableContent);
+        downloadableContent.setGame(this);
+    }
+
+    /**
+     * Convenience method that is used to remove a {@link DownloadableContent} to the {@link Game}. As
+     * the relationship between the {@link Game} and {@link DownloadableContent} is bi-directional,
+     * it needs to be added and associated with on both sides of the relationship, which
+     * this method achieved.
+     *
+     * @param downloadableContent The {@link DownloadableContent} to remove from the {@link Game}.
+     */
+    public void removeDownloadableContent(DownloadableContent downloadableContent) {
+        downloadableContents.remove(downloadableContent);
+        downloadableContent.setGame(null);
     }
 }

--- a/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/GameUserEntry.java
+++ b/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/GameUserEntry.java
@@ -3,6 +3,8 @@ package com.sparkystudios.traklibrary.game.domain;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -37,7 +39,14 @@ public class GameUserEntry {
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
     @OneToMany(mappedBy = "gameUserEntry", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @Fetch(value = FetchMode.SUBSELECT)
     private List<GameUserEntryPlatform> gameUserEntryPlatforms = new ArrayList<>();
+
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    @OneToMany(mappedBy = "gameUserEntry", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @Fetch(value = FetchMode.SUBSELECT)
+    private List<GameUserEntryDownloadableContent> gameUserEntryDownloadableContents = new ArrayList<>();
 
     @Column(name = "status", nullable = false)
     private GameUserEntryStatus status;
@@ -81,5 +90,31 @@ public class GameUserEntry {
     public void removeGameUserEntryPlatform(GameUserEntryPlatform gameUserEntryPlatform) {
         gameUserEntryPlatforms.remove(gameUserEntryPlatform);
         gameUserEntryPlatform.setGameUserEntry(null);
+    }
+
+    /**
+     * Convenience method that is used to add a {@link GameUserEntryDownloadableContent} to the {@link Game}. As
+     * the relationship between the {@link Game} and {@link GameUserEntryDownloadableContent} is bi-directional,
+     * it needs to be added and associated with on both sides of the relationship, which
+     * this method achieved.
+     *
+     * @param gameUserEntryDownloadableContent The {@link GameUserEntryDownloadableContent} to add to the {@link Game}.
+     */
+    public void addGameUserEntryDownloadableContent(GameUserEntryDownloadableContent gameUserEntryDownloadableContent) {
+        gameUserEntryDownloadableContents.add(gameUserEntryDownloadableContent);
+        gameUserEntryDownloadableContent.setGameUserEntry(this);
+    }
+
+    /**
+     * Convenience method that is used to remove a {@link GameUserEntryDownloadableContent} to the {@link Game}. As
+     * the relationship between the {@link Game} and {@link GameUserEntryDownloadableContent} is bi-directional,
+     * it needs to be added and associated with on both sides of the relationship, which
+     * this method achieved.
+     *
+     * @param gameUserEntryDownloadableContent The {@link GameUserEntryDownloadableContent} to remove to the {@link Game}.
+     */
+    public void removeGameUserEntryPlatform(GameUserEntryDownloadableContent gameUserEntryDownloadableContent) {
+        gameUserEntryDownloadableContents.remove(gameUserEntryDownloadableContent);
+        gameUserEntryDownloadableContent.setGameUserEntry(null);
     }
 }

--- a/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/GameUserEntryDownloadableContent.java
+++ b/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/GameUserEntryDownloadableContent.java
@@ -1,0 +1,63 @@
+package com.sparkystudios.traklibrary.game.domain;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Version;
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "game_user_entry_dlc")
+public class GameUserEntryDownloadableContent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", unique = true, nullable = false, updatable = false)
+    private long id;
+
+    @Column(name = "game_user_entry_id", nullable = false, insertable = false, updatable = false)
+    private long gameUserEntryId;
+
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_user_entry_id", nullable = false)
+    private GameUserEntry gameUserEntry;
+
+    @Column(name = "dlc_id", nullable = false, insertable = false, updatable = false)
+    private long downloadableContentId;
+
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "dlc_id", nullable = false)
+    private DownloadableContent downloadableContent;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Version
+    @Column(name = "op_lock_version")
+    private Long version;
+}

--- a/game-domain/src/main/resources/db/changelog/001-initial.xml
+++ b/game-domain/src/main/resources/db/changelog/001-initial.xml
@@ -30,6 +30,40 @@
             <column name="op_lock_version" type="bigint" defaultValueNumeric="0"/>
         </createTable>
 
+        <!-- Create the DLC table -->
+        <createTable tableName="dlc">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false" primaryKeyName="pk_dlc" />
+            </column>
+            <column name="name" type="varchar(255)">
+                <constraints nullable="false" />
+            </column>
+            <column name="description" type="varchar(4096)">
+                <constraints nullable="false" />
+            </column>
+            <column name="release_date" type="date" />
+            <column name="game_id" type="bigint" />
+            <column name="created_at" type="TIMESTAMP WITHOUT TIME ZONE" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP WITHOUT TIME ZONE" defaultValueComputed="CURRENT_TIMESTAMP"/>
+            <column name="op_lock_version" type="bigint" defaultValueNumeric="0"/>
+        </createTable>
+
+        <!-- DLC foreign key constraints -->
+        <addForeignKeyConstraint
+                baseTableName="dlc"
+                baseColumnNames="game_id"
+                constraintName="fk_dlc_game_id"
+                referencedTableName="game"
+                referencedColumnNames="id" />
+
+        <!-- DLC unique constraints -->
+        <addUniqueConstraint
+                tableName="dlc"
+                columnNames="name,game_id"
+                constraintName="unq_dlc_name_game_id" />
+
         <!-- Create the game mode tables -->
         <createTable tableName="game_mode">
             <column name="mode" type="varchar(30)">

--- a/game-domain/src/main/resources/db/changelog/001-initial.xml
+++ b/game-domain/src/main/resources/db/changelog/001-initial.xml
@@ -262,6 +262,44 @@
                 columnNames="game_user_entry_id,platform_id"
                 constraintName="unq_game_user_entry_platform_game_user_entry_id_platform_id" />
 
+        <!-- game_user_entry_dlc table -->
+        <createTable tableName="game_user_entry_dlc">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false" primaryKeyName="pk_game_user_entry_dlc" />
+            </column>
+            <column name="game_user_entry_id" type="bigint">
+                <constraints nullable="false" />
+            </column>
+            <column name="dlc_id" type="bigint">
+                <constraints nullable="false" />
+            </column>
+            <column name="created_at" type="TIMESTAMP WITHOUT TIME ZONE" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP WITHOUT TIME ZONE" defaultValueComputed="CURRENT_TIMESTAMP"/>
+            <column name="op_lock_version" type="bigint" defaultValueNumeric="0"/>
+        </createTable>
+
+        <!-- game_user_entry_platform foreign key constraints -->
+        <addForeignKeyConstraint
+                baseTableName="game_user_entry_dlc"
+                baseColumnNames="game_user_entry_id"
+                constraintName="fk_game_user_entry_dlc_game_user_entry_id"
+                referencedTableName="game_user_entry"
+                referencedColumnNames="id" />
+        <addForeignKeyConstraint
+                baseTableName="game_user_entry_dlc"
+                baseColumnNames="dlc_id"
+                constraintName="fk_game_user_entry_dlc_dlc_id"
+                referencedTableName="dlc"
+                referencedColumnNames="id" />
+
+        <!-- game_user_entry_platform unique constraints -->
+        <addUniqueConstraint
+                tableName="game_user_entry_dlc"
+                columnNames="game_user_entry_id,dlc_id"
+                constraintName="unq_game_user_entry_dlc_game_user_entry_id_dlc_id" />
+
         <!-- game_request table -->
         <createTable tableName="game_request">
             <column name="id" type="bigint" autoIncrement="true">
@@ -563,12 +601,15 @@
             <dropTable tableName="developer" />
             <dropTable tableName="company" />
             <dropTable tableName="game_request" />
+            <dropTable tableName="game_user_entry_dlc" />
+            <dropTable tableName="game_user_entry_platform" />
             <dropTable tableName="game_user_entry" />
             <dropTable tableName="game_platform_xref" />
             <dropTable tableName="platform" />
             <dropTable tableName="game_genre_xref" />
             <dropTable tableName="genre" />
             <dropTable tableName="game_mode" />
+            <dropTable tableName="dlc" />
             <dropTable tableName="game" />
         </rollback>
     </changeSet>

--- a/game-domain/src/test/java/com/sparkystudios/traklibrary/game/domain/DownloadableContentTest.java
+++ b/game-domain/src/test/java/com/sparkystudios/traklibrary/game/domain/DownloadableContentTest.java
@@ -1,0 +1,125 @@
+package com.sparkystudios.traklibrary.game.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import javax.persistence.PersistenceException;
+import java.time.LocalDate;
+import java.util.Collections;
+
+@DataJpaTest
+public class DownloadableContentTest {
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    @Test
+    void persist_withNullName_throwsPersistenceException() {
+        // Arrange
+        DownloadableContent downloadableContent = new DownloadableContent();
+        downloadableContent.setName(null);
+        downloadableContent.setDescription("test-description");
+        downloadableContent.setReleaseDate(LocalDate.now());
+
+        Game game = new Game();
+        game.setTitle("test-title");
+        game.setDescription("test-description");
+        game.setAgeRating(AgeRating.MATURE);
+        game.addDownloadableContent(downloadableContent);
+
+        // Assert
+        Assertions.assertThatExceptionOfType(PersistenceException.class)
+                .isThrownBy(() -> testEntityManager.persistFlushFind(game));
+    }
+
+    @Test
+    void persist_withNameExceedingLength_throwsPersistenceException() {
+        // Arrange
+        DownloadableContent downloadableContent = new DownloadableContent();
+        downloadableContent.setName(String.join("", Collections.nCopies(300, "t")));
+        downloadableContent.setDescription("test-description");
+        downloadableContent.setReleaseDate(LocalDate.now());
+
+        Game game = new Game();
+        game.setTitle("test-title");
+        game.setDescription("test-description");
+        game.setAgeRating(AgeRating.MATURE);
+        game.addDownloadableContent(downloadableContent);
+
+        // Assert
+        Assertions.assertThatExceptionOfType(PersistenceException.class)
+                .isThrownBy(() -> testEntityManager.persistFlushFind(game));
+    }
+
+    @Test
+    void persist_withNullDescription_throwsPersistenceException() {
+        // Arrange
+        DownloadableContent downloadableContent = new DownloadableContent();
+        downloadableContent.setName("test-name");
+        downloadableContent.setDescription(null);
+        downloadableContent.setReleaseDate(LocalDate.now());
+
+        Game game = new Game();
+        game.setTitle("test-title");
+        game.setDescription("test-description");
+        game.setAgeRating(AgeRating.MATURE);
+        game.addDownloadableContent(downloadableContent);
+
+        // Assert
+        Assertions.assertThatExceptionOfType(PersistenceException.class)
+                .isThrownBy(() -> testEntityManager.persistFlushFind(game));
+    }
+
+
+    @Test
+    void persist_withDescriptionExceedingLength_throwsPersistenceException() {
+        // Arrange
+        DownloadableContent downloadableContent = new DownloadableContent();
+        downloadableContent.setName("test-name");
+        downloadableContent.setDescription(String.join("", Collections.nCopies(5000, "t")));
+        downloadableContent.setReleaseDate(LocalDate.now());
+
+        Game game = new Game();
+        game.setTitle("test-title");
+        game.setDescription("test-description");
+        game.setAgeRating(AgeRating.MATURE);
+        game.addDownloadableContent(downloadableContent);
+
+        // Assert
+        Assertions.assertThatExceptionOfType(PersistenceException.class)
+                .isThrownBy(() -> testEntityManager.persistFlushFind(game));
+    }
+
+    @Test
+    void persist_withValidDownloadableContentAndRelationship_mapsDownloadableContent() {
+        // Arrange
+        DownloadableContent downloadableContent = new DownloadableContent();
+        downloadableContent.setName("test-name");
+        downloadableContent.setDescription("test-description");
+        downloadableContent.setReleaseDate(LocalDate.now());
+
+        Game game = new Game();
+        game.setTitle("test-title");
+        game.setDescription("test-description");
+        game.setAgeRating(AgeRating.MATURE);
+        game.addDownloadableContent(downloadableContent);
+
+        // Act
+        game = testEntityManager.persistFlushFind(game);
+        DownloadableContent result = game.getDownloadableContents().iterator().next();
+
+        // Assert
+        Assertions.assertThat(result.getId()).isPositive();
+        Assertions.assertThat(result.getName()).isEqualTo(downloadableContent.getName());
+        Assertions.assertThat(result.getDescription()).isEqualTo(downloadableContent.getDescription());
+        Assertions.assertThat(result.getReleaseDate()).isEqualTo(result.getReleaseDate());
+        Assertions.assertThat(result.getGame().getId())
+                .isEqualTo(game.getId());
+        Assertions.assertThat(result.getCreatedAt()).isNotNull();
+        Assertions.assertThat(result.getUpdatedAt()).isNotNull();
+        Assertions.assertThat(result.getVersion()).isNotNull().isNotNegative();
+    }
+}

--- a/game-domain/src/test/java/com/sparkystudios/traklibrary/game/domain/DownloadableContentTest.java
+++ b/game-domain/src/test/java/com/sparkystudios/traklibrary/game/domain/DownloadableContentTest.java
@@ -11,7 +11,7 @@ import java.time.LocalDate;
 import java.util.Collections;
 
 @DataJpaTest
-public class DownloadableContentTest {
+class DownloadableContentTest {
 
     @Autowired
     private TestEntityManager testEntityManager;

--- a/game-domain/src/test/java/com/sparkystudios/traklibrary/game/domain/GameUserEntryDownloadableContentTest.java
+++ b/game-domain/src/test/java/com/sparkystudios/traklibrary/game/domain/GameUserEntryDownloadableContentTest.java
@@ -10,7 +10,7 @@ import javax.persistence.PersistenceException;
 import java.time.LocalDate;
 
 @DataJpaTest
-public class GameUserEntryDownloadableContentTest {
+class GameUserEntryDownloadableContentTest {
 
     @Autowired
     private TestEntityManager testEntityManager;

--- a/game-domain/src/test/java/com/sparkystudios/traklibrary/game/domain/GameUserEntryDownloadableContentTest.java
+++ b/game-domain/src/test/java/com/sparkystudios/traklibrary/game/domain/GameUserEntryDownloadableContentTest.java
@@ -1,0 +1,108 @@
+package com.sparkystudios.traklibrary.game.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import javax.persistence.PersistenceException;
+import java.time.LocalDate;
+
+@DataJpaTest
+public class GameUserEntryDownloadableContentTest {
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    @Test
+    void persist_withNullGameUserEntry_throwsPersistenceException() {
+        // Arrange
+        DownloadableContent downloadableContent = new DownloadableContent();
+        downloadableContent.setName("test-name-1");
+        downloadableContent.setDescription("test-description-1");
+        downloadableContent.setReleaseDate(LocalDate.now());
+
+        Game game = new Game();
+        game.setTitle("game-title");
+        game.setDescription("game-description");
+        game.setAgeRating(AgeRating.EVERYONE_TEN_PLUS);
+        game.addDownloadableContent(downloadableContent);
+        game = testEntityManager.persistFlushFind(game);
+
+        GameUserEntryDownloadableContent gameUserEntryDownloadableContent = new GameUserEntryDownloadableContent();
+        gameUserEntryDownloadableContent.setGameUserEntry(null);
+        gameUserEntryDownloadableContent.setDownloadableContent(game.getDownloadableContents().iterator().next());
+
+        // Assert
+        Assertions.assertThatExceptionOfType(PersistenceException.class)
+                .isThrownBy(() -> testEntityManager.persistFlushFind(gameUserEntryDownloadableContent));
+    }
+
+    @Test
+    void persist_withNullDownloadableContent_throwsPersistenceException() {
+        // Arrange
+        Game game = new Game();
+        game.setTitle("game-title");
+        game.setDescription("game-description");
+        game.setAgeRating(AgeRating.EVERYONE_TEN_PLUS);
+        game = testEntityManager.persistFlushFind(game);
+
+        GameUserEntry gameUserEntry = new GameUserEntry();
+        gameUserEntry.setGameId(game.getId());
+        gameUserEntry.setUserId(1L);
+        gameUserEntry.setStatus(GameUserEntryStatus.COMPLETED);
+        gameUserEntry.setRating((short)5);
+        gameUserEntry = testEntityManager.persistFlushFind(gameUserEntry);
+
+        GameUserEntryDownloadableContent gameUserEntryDownloadableContent = new GameUserEntryDownloadableContent();
+        gameUserEntryDownloadableContent.setGameUserEntry(gameUserEntry);
+        gameUserEntryDownloadableContent.setDownloadableContent(null);
+
+        // Assert
+        Assertions.assertThatExceptionOfType(PersistenceException.class)
+                .isThrownBy(() -> testEntityManager.persistFlushFind(gameUserEntryDownloadableContent));
+    }
+
+    @Test
+    void persist_withValidGameUserEntryPlatform_mapsGameUserEntryPlatform() {
+        // Arrange
+        DownloadableContent downloadableContent = new DownloadableContent();
+        downloadableContent.setName("test-name-1");
+        downloadableContent.setDescription("test-description-1");
+        downloadableContent.setReleaseDate(LocalDate.now());
+
+        Game game = new Game();
+        game.setTitle("game-title");
+        game.setDescription("game-description");
+        game.setAgeRating(AgeRating.EVERYONE_TEN_PLUS);
+        game.addDownloadableContent(downloadableContent);
+        game = testEntityManager.persistFlushFind(game);
+
+        GameUserEntry gameUserEntry = new GameUserEntry();
+        gameUserEntry.setGameId(game.getId());
+        gameUserEntry.setUserId(1L);
+        gameUserEntry.setStatus(GameUserEntryStatus.COMPLETED);
+        gameUserEntry.setRating((short)5);
+        gameUserEntry = testEntityManager.persistFlushFind(gameUserEntry);
+
+        GameUserEntryDownloadableContent gameUserEntryDownloadableContent = new GameUserEntryDownloadableContent();
+        gameUserEntryDownloadableContent.setGameUserEntry(gameUserEntry);
+        gameUserEntryDownloadableContent.setDownloadableContent(game.getDownloadableContents().iterator().next());
+
+        // Act
+        GameUserEntryDownloadableContent result = testEntityManager.persistFlushFind(gameUserEntryDownloadableContent);
+
+        // Assert
+        DownloadableContent dc = game.getDownloadableContents().iterator().next();
+
+        Assertions.assertThat(result.getId()).isPositive();
+        Assertions.assertThat(result.getGameUserEntryId()).isEqualTo(gameUserEntry.getId());
+        Assertions.assertThat(result.getGameUserEntry().getId()).isEqualTo(gameUserEntry.getId());
+        Assertions.assertThat(result.getDownloadableContentId()).isEqualTo(dc.getId());
+        Assertions.assertThat(result.getDownloadableContent().getId()).isEqualTo(dc.getId());
+        Assertions.assertThat(result.getCreatedAt()).isNotNull();
+        Assertions.assertThat(result.getUpdatedAt()).isNotNull();
+        Assertions.assertThat(result.getVersion()).isNotNull().isNotNegative();
+    }
+}

--- a/game-domain/src/test/java/com/sparkystudios/traklibrary/game/domain/GameUserEntryTest.java
+++ b/game-domain/src/test/java/com/sparkystudios/traklibrary/game/domain/GameUserEntryTest.java
@@ -7,6 +7,8 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
 import javax.persistence.PersistenceException;
+import java.time.LocalDate;
+import java.util.Iterator;
 
 @DataJpaTest
 class GameUserEntryTest {
@@ -83,5 +85,49 @@ class GameUserEntryTest {
 
         // Assert
         Assertions.assertThat(result.getGameUserEntryPlatforms()).hasSize(2);
+    }
+
+    @Test
+    void persist_withValidGameUserEntryDownloadableContentRelationships_mapsRelationship() {
+        // Arrange
+        DownloadableContent downloadableContent1 = new DownloadableContent();
+        downloadableContent1.setName("test-name-1");
+        downloadableContent1.setDescription("test-description-1");
+        downloadableContent1.setReleaseDate(LocalDate.now());
+
+        DownloadableContent downloadableContent2 = new DownloadableContent();
+        downloadableContent2.setName("test-name-2");
+        downloadableContent2.setDescription("test-description-2");
+        downloadableContent2.setReleaseDate(LocalDate.now());
+
+        Game game = new Game();
+        game.setTitle("game-title");
+        game.setDescription("game-description");
+        game.setAgeRating(AgeRating.EVERYONE_TEN_PLUS);
+        game.addDownloadableContent(downloadableContent1);
+        game.addDownloadableContent(downloadableContent2);
+        game = testEntityManager.persistFlushFind(game);
+
+        Iterator<DownloadableContent> itr = game.getDownloadableContents().iterator();
+
+        GameUserEntryDownloadableContent gameUserEntryDownloadableContent1 = new GameUserEntryDownloadableContent();
+        gameUserEntryDownloadableContent1.setDownloadableContent(itr.next());
+
+        GameUserEntryDownloadableContent gameUserEntryDownloadableContent2 = new GameUserEntryDownloadableContent();
+        gameUserEntryDownloadableContent2.setDownloadableContent(itr.next());
+
+        GameUserEntry gameUserEntry = new GameUserEntry();
+        gameUserEntry.setGameId(game.getId());
+        gameUserEntry.setUserId(1L);
+        gameUserEntry.setStatus(GameUserEntryStatus.COMPLETED);
+        gameUserEntry.setRating((short)5);
+        gameUserEntry.addGameUserEntryDownloadableContent(gameUserEntryDownloadableContent1);
+        gameUserEntry.addGameUserEntryDownloadableContent(gameUserEntryDownloadableContent2);
+
+        // Act
+        GameUserEntry result = testEntityManager.persistFlushFind(gameUserEntry);
+
+        // Assert
+        Assertions.assertThat(result.getGameUserEntryDownloadableContents()).hasSize(2);
     }
 }

--- a/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/DownloadableContentRepository.java
+++ b/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/DownloadableContentRepository.java
@@ -1,0 +1,8 @@
+package com.sparkystudios.traklibrary.game.repository;
+
+import com.sparkystudios.traklibrary.game.domain.DownloadableContent;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+public interface DownloadableContentRepository extends PagingAndSortingRepository<DownloadableContent, Long>, JpaSpecificationExecutor<DownloadableContent> {
+}

--- a/game-server/src/main/resources/i18n/validation.properties
+++ b/game-server/src/main/resources/i18n/validation.properties
@@ -3,6 +3,10 @@ company.validation.description.size=The description cannot exceed 4096 character
 company.validation.founded-date.not-null=The founded date cannot be null.
 company.validation.company-type.not-null=The company type cannot be null.
 
+downloadable-content.validation.title.not-empty=The title cannot be empty or null.
+downloadable-content.validation.title.size=The title cannot exceed 255 characters.
+downloadable-content.validation.description.size=The description cannot exceed 255 characters.
+
 franchise.validation.title.not-empty=The title cannot be empty or null.
 franchise.validation.title.size=The description cannot exceed 255 characters.
 
@@ -18,7 +22,6 @@ game-request.validation.description.size=The notes cannot exceed 1024 characters
 game-user-entry-request.validation.platforms.not-null=The platforms cannot be null.
 game-user-entry-request.validation.platforms.not-empty=The platforms cannot be empty.
 game-user-entry-request.validation.downloadable-contents.not-null=The downloadable content ID's cannot be null.
-game-user-entry-request.validation.downloadable-contents.not-empty=The downloadable content ID's cannot be empty.
 game-user-entry-request.validation.rating.min=The rating value cannot be less than 0.
 game-user-entry-request.validation.rating.max=The rating value cannot be more than 5.
 game-user-entry-request.validation.status.not-null=The status cannot be empty or null.

--- a/game-server/src/main/resources/i18n/validation.properties
+++ b/game-server/src/main/resources/i18n/validation.properties
@@ -17,6 +17,8 @@ game-request.validation.description.size=The notes cannot exceed 1024 characters
 
 game-user-entry-request.validation.platforms.not-null=The platforms cannot be null.
 game-user-entry-request.validation.platforms.not-empty=The platforms cannot be empty.
+game-user-entry-request.validation.downloadable-contents.not-null=The downloadable content ID's cannot be null.
+game-user-entry-request.validation.downloadable-contents.not-empty=The downloadable content ID's cannot be empty.
 game-user-entry-request.validation.rating.min=The rating value cannot be less than 0.
 game-user-entry-request.validation.rating.max=The rating value cannot be more than 5.
 game-user-entry-request.validation.status.not-null=The status cannot be empty or null.

--- a/game-server/src/main/resources/i18n/validation_en.properties
+++ b/game-server/src/main/resources/i18n/validation_en.properties
@@ -3,6 +3,10 @@ company.validation.description.size=The description cannot exceed 4096 character
 company.validation.founded-date.not-null=The founded date cannot be null.
 company.validation.company-type.not-null=The company type cannot be null.
 
+downloadable-content.validation.title.not-empty=The title cannot be empty or null.
+downloadable-content.validation.title.size=The title cannot exceed 255 characters.
+downloadable-content.validation.description.size=The description cannot exceed 255 characters.
+
 franchise.validation.title.not-empty=The title cannot be empty or null.
 franchise.validation.title.size=The description cannot exceed 255 characters.
 
@@ -18,7 +22,6 @@ game-request.validation.description.size=The notes cannot exceed 1024 characters
 game-user-entry-request.validation.platforms.not-null=The platforms cannot be null.
 game-user-entry-request.validation.platforms.not-empty=The platforms cannot be empty.
 game-user-entry-request.validation.downloadable-contents.not-null=The downloadable content ID's cannot be null.
-game-user-entry-request.validation.downloadable-contents.not-empty=The downloadable content ID's cannot be empty.
 game-user-entry-request.validation.rating.min=The rating value cannot be less than 0.
 game-user-entry-request.validation.rating.max=The rating value cannot be more than 5.
 game-user-entry-request.validation.status.not-null=The status cannot be empty or null.

--- a/game-server/src/main/resources/i18n/validation_en.properties
+++ b/game-server/src/main/resources/i18n/validation_en.properties
@@ -17,6 +17,8 @@ game-request.validation.description.size=The notes cannot exceed 1024 characters
 
 game-user-entry-request.validation.platforms.not-null=The platforms cannot be null.
 game-user-entry-request.validation.platforms.not-empty=The platforms cannot be empty.
+game-user-entry-request.validation.downloadable-contents.not-null=The downloadable content ID's cannot be null.
+game-user-entry-request.validation.downloadable-contents.not-empty=The downloadable content ID's cannot be empty.
 game-user-entry-request.validation.rating.min=The rating value cannot be less than 0.
 game-user-entry-request.validation.rating.max=The rating value cannot be more than 5.
 game-user-entry-request.validation.status.not-null=The status cannot be empty or null.

--- a/game-server/src/test/java/com/sparkystudios/traklibrary/game/server/controller/GameUserEntryControllerTest.java
+++ b/game-server/src/test/java/com/sparkystudios/traklibrary/game/server/controller/GameUserEntryControllerTest.java
@@ -82,6 +82,7 @@ class GameUserEntryControllerTest {
         gameUserEntryRequest.setRating((short)1);
         gameUserEntryRequest.setStatus(GameUserEntryStatus.COMPLETED);
         gameUserEntryRequest.setPlatformIds(Collections.singletonList(1L));
+        gameUserEntryRequest.setDownloadableContentIds(Collections.singletonList(1L));
 
         Mockito.when(gameUserEntryService.save(ArgumentMatchers.any()))
                 .thenReturn(new GameUserEntryDto());
@@ -283,6 +284,7 @@ class GameUserEntryControllerTest {
         gameUserEntryRequest.setRating((short)1);
         gameUserEntryRequest.setStatus(GameUserEntryStatus.COMPLETED);
         gameUserEntryRequest.setPlatformIds(Collections.singletonList(1L));
+        gameUserEntryRequest.setDownloadableContentIds(Collections.singletonList(1L));
 
         Mockito.when(gameUserEntryService.update(ArgumentMatchers.any()))
                 .thenReturn(new GameUserEntryDto());

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/dto/DownloadableContentDto.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/dto/DownloadableContentDto.java
@@ -1,0 +1,54 @@
+package com.sparkystudios.traklibrary.game.service.dto;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ComparisonChain;
+import lombok.Data;
+import org.springframework.hateoas.server.core.Relation;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@Relation(collectionRelation = "data", itemRelation = "dlc")
+public class DownloadableContentDto implements Comparable<DownloadableContentDto> {
+
+    private long id;
+
+    @NotEmpty(message = "{downloadable-content.validation.title.not-empty}")
+    @Size(max = 255, message = "{downloadable-content.validation.title.size}")
+    private String name;
+
+    @Size(max = 4096, message = "{downloadable-content.validation.description.size}")
+    private String description;
+
+    private LocalDate releaseDate;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private Long version;
+
+    /**
+     * Used for comparison between two {@link DownloadableContentDto} objects. It's used
+     * internally whenever a {@link DownloadableContentDto} is the type within a list which
+     * supported inserted sort, such as a {@link java.util.TreeSet}.
+     *
+     * The order in which {@link DownloadableContentDto} instances are sorted are by {@link DownloadableContentDto#name}
+     * and {@link DownloadableContentDto#id}.
+     *
+     * @param other The other {@link DownloadableContentDto} instance to compare against.
+     *
+     * @return a negative integer, zero, or a positive integer as this {@link DownloadableContentDto}
+     *         is less than, equal to, or greater than the specified object.
+     */
+    @Override
+    public int compareTo(DownloadableContentDto other) {
+        return ComparisonChain.start()
+                .compare(Strings.nullToEmpty(name), Strings.nullToEmpty(other.name))
+                .compare(id, other.id)
+                .result();
+    }
+}

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/dto/GameDetailsDto.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/dto/GameDetailsDto.java
@@ -40,5 +40,7 @@ public class GameDetailsDto {
 
     private Set<GameReleaseDateDto> releaseDates = new TreeSet<>();
 
+    private Set<DownloadableContentDto> downloadableContents = new TreeSet<>();
+
     private FranchiseDto franchise;
 }

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/dto/GameDto.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/dto/GameDto.java
@@ -38,5 +38,7 @@ public class GameDto {
 
     private Long version;
 
-    private TreeSet<GameReleaseDateDto> releaseDates = new TreeSet<>();
+    private Set<GameReleaseDateDto> releaseDates = new TreeSet<>();
+
+    private Set<DownloadableContentDto> downloadableContents = new TreeSet<>();
 }

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/dto/GameUserEntryDownloadableContentDto.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/dto/GameUserEntryDownloadableContentDto.java
@@ -1,0 +1,47 @@
+package com.sparkystudios.traklibrary.game.service.dto;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ComparisonChain;
+import lombok.Data;
+import org.springframework.hateoas.server.core.Relation;
+
+import java.time.LocalDateTime;
+
+@Data
+@Relation(collectionRelation = "data", itemRelation = "game-user-entry-dlc")
+public class GameUserEntryDownloadableContentDto implements Comparable<GameUserEntryDownloadableContentDto> {
+
+    private long id;
+
+    private long gameUserEntryId;
+
+    private long downloadableContentId;
+
+    private String downloadableContentName;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private Long version;
+
+    /**
+     * Used for comparison between two {@link GameUserEntryDownloadableContentDto} objects. It's used
+     * internally whenever a {@link GameUserEntryDownloadableContentDto} is the type within a list which
+     * supported inserted sort, such as a {@link java.util.TreeSet}.
+     * <p>
+     * The order in which {@link GameUserEntryDownloadableContentDto} instances are sorted are by {@link GameUserEntryDownloadableContentDto#downloadableContentName},
+     * and then {@link GameUserEntryDownloadableContentDto#id}.
+     *
+     * @param other The other {@link GameUserEntryDownloadableContentDto} instance to compare against.
+     * @return a negative integer, zero, or a positive integer as this {@link GameUserEntryDownloadableContentDto}
+     * is less than, equal to, or greater than the specified object.
+     */
+    @Override
+    public int compareTo(GameUserEntryDownloadableContentDto other) {
+        return ComparisonChain.start()
+                .compare(Strings.nullToEmpty(downloadableContentName), Strings.nullToEmpty(other.downloadableContentName))
+                .compare(id, other.id)
+                .result();
+    }
+}

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/dto/GameUserEntryDto.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/dto/GameUserEntryDto.java
@@ -30,6 +30,8 @@ public class GameUserEntryDto {
 
     private Set<GameUserEntryPlatformDto> gameUserEntryPlatforms = new TreeSet<>();
 
+    private Set<GameUserEntryDownloadableContentDto> gameUserEntryDownloadableContents = new TreeSet<>();
+
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/dto/request/GameUserEntryRequest.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/dto/request/GameUserEntryRequest.java
@@ -30,6 +30,5 @@ public class GameUserEntryRequest {
     private Collection<Long> platformIds;
 
     @NotNull(message = "{game-user-entry-request.validation.downloadable-contents.not-null}")
-    @NotEmpty(message = "{game-user-entry-request.validation.downloadable-contents.not-empty}")
     private Collection<Long> downloadableContentIds;
 }

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/dto/request/GameUserEntryRequest.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/dto/request/GameUserEntryRequest.java
@@ -28,4 +28,8 @@ public class GameUserEntryRequest {
     @NotNull(message = "{game-user-entry-request.validation.platforms.not-null}")
     @NotEmpty(message = "{game-user-entry-request.validation.platforms.not-empty}")
     private Collection<Long> platformIds;
+
+    @NotNull(message = "{game-user-entry-request.validation.downloadable-contents.not-null}")
+    @NotEmpty(message = "{game-user-entry-request.validation.downloadable-contents.not-empty}")
+    private Collection<Long> downloadableContentIds;
 }

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/impl/GameServiceImpl.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/impl/GameServiceImpl.java
@@ -59,6 +59,7 @@ public class GameServiceImpl implements GameService {
 
         Game game = gameMapper.gameDtoToGame(gameDto);
         game.getReleaseDates().forEach(gameReleaseDate -> gameReleaseDate.setGame(game));
+        game.getDownloadableContents().forEach(downloadableContent -> downloadableContent.setGame(game));
 
         // We need to retrieve the game by the new ID as we want the release dates joined to the result.
         return gameMapper.gameToGameDto(gameRepository.save(game));
@@ -420,6 +421,7 @@ public class GameServiceImpl implements GameService {
 
         Game game = gameMapper.gameDtoToGame(gameDto);
         game.getReleaseDates().forEach(gameReleaseDate -> gameReleaseDate.setGame(game));
+        game.getDownloadableContents().forEach(downloadableContent -> downloadableContent.setGame(game));
 
         return gameMapper.gameToGameDto(gameRepository.save(game));
     }

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/mapper/DownloadableContentMapper.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/mapper/DownloadableContentMapper.java
@@ -1,0 +1,17 @@
+package com.sparkystudios.traklibrary.game.service.mapper;
+
+import com.sparkystudios.traklibrary.game.domain.DownloadableContent;
+import com.sparkystudios.traklibrary.game.service.dto.DownloadableContentDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface DownloadableContentMapper {
+
+    DownloadableContentDto downloadableContentToDownloadableContentDto(DownloadableContent downloadableContent);
+
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "game", ignore = true)
+    DownloadableContent downloadableContentDtoToDownloadableContent(DownloadableContentDto downloadableContentDto);
+}

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/mapper/GameDetailsMapper.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/mapper/GameDetailsMapper.java
@@ -28,4 +28,8 @@ public interface GameDetailsMapper {
     default FranchiseDto franchiseToFranchiseDto(Franchise franchise) {
         return GameMappers.FRANCHISE_MAPPER.franchiseToFranchiseDto(franchise);
     }
+
+    default DownloadableContentDto downloadableContentToDownloadableContentDto(DownloadableContent downloadableContent) {
+        return GameMappers.DOWNLOADABLE_CONTENT_MAPPER.downloadableContentToDownloadableContentDto(downloadableContent);
+    }
 }

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/mapper/GameMapper.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/mapper/GameMapper.java
@@ -1,7 +1,9 @@
 package com.sparkystudios.traklibrary.game.service.mapper;
 
+import com.sparkystudios.traklibrary.game.domain.DownloadableContent;
 import com.sparkystudios.traklibrary.game.domain.Game;
 import com.sparkystudios.traklibrary.game.domain.GameReleaseDate;
+import com.sparkystudios.traklibrary.game.service.dto.DownloadableContentDto;
 import com.sparkystudios.traklibrary.game.service.dto.GameDto;
 import com.sparkystudios.traklibrary.game.service.dto.GameReleaseDateDto;
 import org.mapstruct.Mapper;
@@ -27,5 +29,13 @@ public interface GameMapper {
 
     default GameReleaseDate gameReleaseDateDtoToGameReleaseDate(GameReleaseDateDto gameReleaseDateDto) {
         return GameMappers.GAME_RELEASE_DATE_MAPPER.gameReleaseDateDtoToGameReleaseDate(gameReleaseDateDto);
+    }
+
+    default DownloadableContentDto downloadableContentToDownloadableContentDto(DownloadableContent downloadableContent) {
+        return GameMappers.DOWNLOADABLE_CONTENT_MAPPER.downloadableContentToDownloadableContentDto(downloadableContent);
+    }
+
+    default DownloadableContent downloadableContentDtoToDownloadContent(DownloadableContentDto downloadableContentDto) {
+        return GameMappers.DOWNLOADABLE_CONTENT_MAPPER.downloadableContentDtoToDownloadableContent(downloadableContentDto);
     }
 }

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/mapper/GameMappers.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/mapper/GameMappers.java
@@ -25,6 +25,8 @@ public final class GameMappers {
 
     public static final GameUserEntryPlatformMapper GAME_USER_ENTRY_PLATFORM_MAPPER = Mappers.getMapper(GameUserEntryPlatformMapper.class);
 
+    public static final GameUserEntryDownloadableContentMapper GAME_USER_ENTRY_DOWNLOADABLE_CONTENT_MAPPER = Mappers.getMapper(GameUserEntryDownloadableContentMapper.class);
+
     public static final GenreMapper GENRE_MAPPER = Mappers.getMapper(GenreMapper.class);
 
     public static final PlatformMapper PLATFORM_MAPPER = Mappers.getMapper(PlatformMapper.class);

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/mapper/GameMappers.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/mapper/GameMappers.java
@@ -9,6 +9,8 @@ public final class GameMappers {
 
     public static final DeveloperMapper DEVELOPER_MAPPER = Mappers.getMapper(DeveloperMapper.class);
 
+    public static final DownloadableContentMapper DOWNLOADABLE_CONTENT_MAPPER = Mappers.getMapper(DownloadableContentMapper.class);
+
     public static final FranchiseMapper FRANCHISE_MAPPER = Mappers.getMapper(FranchiseMapper.class);
 
     public static final GameBarcodeMapper GAME_BARCODE_MAPPER = Mappers.getMapper(GameBarcodeMapper.class);

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/mapper/GameUserEntryDownloadableContentMapper.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/mapper/GameUserEntryDownloadableContentMapper.java
@@ -1,0 +1,13 @@
+package com.sparkystudios.traklibrary.game.service.mapper;
+
+import com.sparkystudios.traklibrary.game.domain.GameUserEntryDownloadableContent;
+import com.sparkystudios.traklibrary.game.service.dto.GameUserEntryDownloadableContentDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface GameUserEntryDownloadableContentMapper {
+
+    @Mapping(source = "downloadableContent.name", target = "downloadableContentName")
+    GameUserEntryDownloadableContentDto gameUserEntryDownloadableContentToGameUserEntryDownloadableContentDto(GameUserEntryDownloadableContent gameUserEntryDownloadableContent);
+}

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/mapper/GameUserEntryMapper.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/mapper/GameUserEntryMapper.java
@@ -1,8 +1,10 @@
 package com.sparkystudios.traklibrary.game.service.mapper;
 
 import com.sparkystudios.traklibrary.game.domain.GameUserEntry;
+import com.sparkystudios.traklibrary.game.domain.GameUserEntryDownloadableContent;
 import com.sparkystudios.traklibrary.game.domain.GameUserEntryPlatform;
 import com.sparkystudios.traklibrary.game.domain.Publisher;
+import com.sparkystudios.traklibrary.game.service.dto.GameUserEntryDownloadableContentDto;
 import com.sparkystudios.traklibrary.game.service.dto.GameUserEntryDto;
 import com.sparkystudios.traklibrary.game.service.dto.GameUserEntryPlatformDto;
 import org.mapstruct.Mapper;
@@ -21,5 +23,9 @@ public interface GameUserEntryMapper {
 
     default GameUserEntryPlatformDto gameUserEntryPlatformToGameUserEntryPlatformDto(GameUserEntryPlatform gameUserEntryPlatform) {
         return GameMappers.GAME_USER_ENTRY_PLATFORM_MAPPER.gameUserEntryPlatformToGameUserEntryPlatformDto(gameUserEntryPlatform);
+    }
+
+    default GameUserEntryDownloadableContentDto gameUserEntryDownloadableContentToGameUserEntryDownloadableContentDto(GameUserEntryDownloadableContent gameUserEntryDownloadableContent) {
+        return GameMappers.GAME_USER_ENTRY_DOWNLOADABLE_CONTENT_MAPPER.gameUserEntryDownloadableContentToGameUserEntryDownloadableContentDto(gameUserEntryDownloadableContent);
     }
 }

--- a/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/dto/DownloadableContentDtoTest.java
+++ b/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/dto/DownloadableContentDtoTest.java
@@ -3,7 +3,7 @@ package com.sparkystudios.traklibrary.game.service.dto;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class DownloadableContentDtoTest {
+class DownloadableContentDtoTest {
 
     @Test
     void compareTo_withNullName_returnsCorrectComparison() {

--- a/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/dto/DownloadableContentDtoTest.java
+++ b/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/dto/DownloadableContentDtoTest.java
@@ -1,0 +1,79 @@
+package com.sparkystudios.traklibrary.game.service.dto;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DownloadableContentDtoTest {
+
+    @Test
+    void compareTo_withNullName_returnsCorrectComparison() {
+        // Arrange
+        DownloadableContentDto downloadableContentDto = new DownloadableContentDto();
+        downloadableContentDto.setId(5L);
+        downloadableContentDto.setName("A");
+
+        DownloadableContentDto comparison = new DownloadableContentDto();
+        comparison.setId(4L);
+        comparison.setName(null);
+
+        // Act
+        int result = downloadableContentDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(1);
+    }
+
+    @Test
+    void compareTo_withAscendingName_returnsCorrectComparison() {
+        // Arrange
+        DownloadableContentDto downloadableContentDto = new DownloadableContentDto();
+        downloadableContentDto.setId(5L);
+        downloadableContentDto.setName("A");
+
+        DownloadableContentDto comparison = new DownloadableContentDto();
+        comparison.setId(4L);
+        comparison.setName("B");
+
+        // Act
+        int result = downloadableContentDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    void compareTo_withAscendingId_returnsCorrectComparison() {
+        // Arrange
+        DownloadableContentDto downloadableContentDto = new DownloadableContentDto();
+        downloadableContentDto.setId(4L);
+        downloadableContentDto.setName("A");
+
+        DownloadableContentDto comparison = new DownloadableContentDto();
+        comparison.setId(5L);
+        comparison.setName("A");
+
+        // Act
+        int result = downloadableContentDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    void compareTo_withMatchingPlatforms_returnsCorrectComparison() {
+        // Arrange
+        DownloadableContentDto downloadableContentDto = new DownloadableContentDto();
+        downloadableContentDto.setId(5L);
+        downloadableContentDto.setName("A");
+
+        DownloadableContentDto comparison = new DownloadableContentDto();
+        comparison.setId(5L);
+        comparison.setName("A");
+
+        // Act
+        int result = downloadableContentDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isZero();
+    }
+}

--- a/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/dto/GameUserEntryDownloadableContentDtoTest.java
+++ b/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/dto/GameUserEntryDownloadableContentDtoTest.java
@@ -1,0 +1,79 @@
+package com.sparkystudios.traklibrary.game.service.dto;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class GameUserEntryDownloadableContentDtoTest {
+
+    @Test
+    void compareTo_withNullDownloadableContentName_returnsCorrectComparison() {
+        // Arrange
+        GameUserEntryDownloadableContentDto gameUserEntryDownloadableContentDto = new GameUserEntryDownloadableContentDto();
+        gameUserEntryDownloadableContentDto.setId(5L);
+        gameUserEntryDownloadableContentDto.setDownloadableContentName("");
+
+        GameUserEntryDownloadableContentDto comparison = new GameUserEntryDownloadableContentDto();
+        comparison.setId(4L);
+        comparison.setDownloadableContentName("A");
+
+        // Act
+        int result = gameUserEntryDownloadableContentDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    void compareTo_withAscendingDownloadableContentName_returnsCorrectComparison() {
+        // Arrange
+        GameUserEntryDownloadableContentDto gameUserEntryDownloadableContentDto = new GameUserEntryDownloadableContentDto();
+        gameUserEntryDownloadableContentDto.setId(5L);
+        gameUserEntryDownloadableContentDto.setDownloadableContentName("A");
+
+        GameUserEntryDownloadableContentDto comparison = new GameUserEntryDownloadableContentDto();
+        comparison.setId(4L);
+        comparison.setDownloadableContentName("B");
+
+        // Act
+        int result = gameUserEntryDownloadableContentDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    void compareTo_withAscendingId_returnsCorrectComparison() {
+        // Arrange
+        GameUserEntryDownloadableContentDto gameUserEntryDownloadableContentDto = new GameUserEntryDownloadableContentDto();
+        gameUserEntryDownloadableContentDto.setId(4L);
+        gameUserEntryDownloadableContentDto.setDownloadableContentName("A");
+
+        GameUserEntryDownloadableContentDto comparison = new GameUserEntryDownloadableContentDto();
+        comparison.setId(5L);
+        comparison.setDownloadableContentName("A");
+
+        // Act
+        int result = gameUserEntryDownloadableContentDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    void compareTo_withMatchingGameUserEntryDownloadableContentDtos_returnsCorrectComparison() {
+        // Arrange
+        GameUserEntryDownloadableContentDto gameUserEntryDownloadableContentDto = new GameUserEntryDownloadableContentDto();
+        gameUserEntryDownloadableContentDto.setId(5L);
+        gameUserEntryDownloadableContentDto.setDownloadableContentName("A");
+
+        GameUserEntryDownloadableContentDto comparison = new GameUserEntryDownloadableContentDto();
+        comparison.setId(5L);
+        comparison.setDownloadableContentName("A");
+
+        // Act
+        int result = gameUserEntryDownloadableContentDto.compareTo(comparison);
+
+        // Assert
+        Assertions.assertThat(result).isZero();
+    }
+}

--- a/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/impl/GameUserEntryServiceImplTest.java
+++ b/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/impl/GameUserEntryServiceImplTest.java
@@ -511,7 +511,7 @@ class GameUserEntryServiceImplTest {
         gameUserEntryRequest.setPlatformIds(platformIds);
         gameUserEntryRequest.setDownloadableContentIds(Collections.emptyList());
 
-        Mockito.when(platformRepository.findById(ArgumentMatchers.eq(3L)))
+        Mockito.when(platformRepository.findById(3L))
                 .thenReturn(Optional.of(new Platform()));
 
         // Act
@@ -593,7 +593,7 @@ class GameUserEntryServiceImplTest {
         gameUserEntryRequest.setPlatformIds(Collections.emptyList());
         gameUserEntryRequest.setDownloadableContentIds(downloadableContentIds);
 
-        Mockito.when(downloadableContentRepository.findById(ArgumentMatchers.eq(3L)))
+        Mockito.when(downloadableContentRepository.findById(3L))
                 .thenReturn(Optional.of(new DownloadableContent()));
 
         // Act

--- a/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/impl/GameUserEntryServiceImplTest.java
+++ b/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/impl/GameUserEntryServiceImplTest.java
@@ -1,8 +1,11 @@
 package com.sparkystudios.traklibrary.game.service.impl;
 
+import com.sparkystudios.traklibrary.game.domain.DownloadableContent;
 import com.sparkystudios.traklibrary.game.domain.GameUserEntry;
+import com.sparkystudios.traklibrary.game.domain.GameUserEntryDownloadableContent;
 import com.sparkystudios.traklibrary.game.domain.GameUserEntryPlatform;
 import com.sparkystudios.traklibrary.game.domain.Platform;
+import com.sparkystudios.traklibrary.game.repository.DownloadableContentRepository;
 import com.sparkystudios.traklibrary.game.repository.GameRepository;
 import com.sparkystudios.traklibrary.game.repository.GameUserEntryRepository;
 import com.sparkystudios.traklibrary.game.repository.PlatformRepository;
@@ -40,6 +43,9 @@ class GameUserEntryServiceImplTest {
 
     @Mock
     private PlatformRepository platformRepository;
+
+    @Mock
+    private DownloadableContentRepository downloadableContentRepository;
 
     @Spy
     private final GameUserEntryMapper gameUserEntryMapper = GameMappers.GAME_USER_ENTRY_MAPPER;
@@ -113,11 +119,15 @@ class GameUserEntryServiceImplTest {
 
         GameUserEntryRequest gameUserEntryRequest = new GameUserEntryRequest();
         gameUserEntryRequest.setPlatformIds(Collections.emptyList());
+        gameUserEntryRequest.setDownloadableContentIds(Collections.emptyList());
 
         // Act
         gameUserEntryService.save(gameUserEntryRequest);
 
         // Assert
+        Mockito.verify(platformRepository, Mockito.never())
+                .findById(ArgumentMatchers.anyLong());
+
         Mockito.verify(gameUserEntryRepository, Mockito.atMostOnce())
                 .save(ArgumentMatchers.any());
     }
@@ -135,16 +145,74 @@ class GameUserEntryServiceImplTest {
                 .thenReturn(new GameUserEntry());
 
         Mockito.when(platformRepository.findById(ArgumentMatchers.anyLong()))
-                .thenReturn(Optional.empty());
+                .thenReturn(Optional.of(new Platform()));
 
         GameUserEntryRequest gameUserEntryRequest = Mockito.spy(GameUserEntryRequest.class);
         gameUserEntryRequest.setPlatformIds(List.of(1L, 2L));
+        gameUserEntryRequest.setDownloadableContentIds(Collections.emptyList());
 
         // Act
         gameUserEntryService.save(gameUserEntryRequest);
 
         // Assert
         Mockito.verify(platformRepository, Mockito.atMost(2))
+                .findById(ArgumentMatchers.anyLong());
+
+        Mockito.verify(gameUserEntryRepository, Mockito.atMostOnce())
+                .save(ArgumentMatchers.any());
+    }
+
+    @Test
+    void save_withNewGameUserEntryRequestWithNoDownloadableContents_savesGameUserEntry() {
+        // Arrange
+        Mockito.when(authenticationService.isCurrentAuthenticatedUser(ArgumentMatchers.anyLong()))
+                .thenReturn(true);
+
+        Mockito.when(gameUserEntryRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(false);
+
+        Mockito.when(gameUserEntryRepository.save(ArgumentMatchers.any()))
+                .thenReturn(new GameUserEntry());
+
+        GameUserEntryRequest gameUserEntryRequest = new GameUserEntryRequest();
+        gameUserEntryRequest.setPlatformIds(Collections.emptyList());
+        gameUserEntryRequest.setDownloadableContentIds(Collections.emptyList());
+
+        // Act
+        gameUserEntryService.save(gameUserEntryRequest);
+
+        // Assert
+        Mockito.verify(downloadableContentRepository, Mockito.never())
+                .findById(ArgumentMatchers.anyLong());
+
+        Mockito.verify(gameUserEntryRepository, Mockito.atMostOnce())
+                .save(ArgumentMatchers.any());
+    }
+
+    @Test
+    void save_withNewGameUserEntryRequestWithDownloadableContentIds_savesGameUserEntryAndInvokesDownloadableContentRepository() {
+        // Arrange
+        Mockito.when(authenticationService.isCurrentAuthenticatedUser(ArgumentMatchers.anyLong()))
+                .thenReturn(true);
+
+        Mockito.when(gameUserEntryRepository.existsById(ArgumentMatchers.anyLong()))
+                .thenReturn(false);
+
+        Mockito.when(gameUserEntryRepository.save(ArgumentMatchers.any()))
+                .thenReturn(new GameUserEntry());
+
+        Mockito.when(downloadableContentRepository.findById(ArgumentMatchers.anyLong()))
+                .thenReturn(Optional.of(new DownloadableContent()));
+
+        GameUserEntryRequest gameUserEntryRequest = Mockito.spy(GameUserEntryRequest.class);
+        gameUserEntryRequest.setPlatformIds(Collections.emptyList());
+        gameUserEntryRequest.setDownloadableContentIds(List.of(1L, 2L));
+
+        // Act
+        gameUserEntryService.save(gameUserEntryRequest);
+
+        // Assert
+        Mockito.verify(downloadableContentRepository, Mockito.atMost(2))
                 .findById(ArgumentMatchers.anyLong());
 
         Mockito.verify(gameUserEntryRepository, Mockito.atMostOnce())
@@ -386,6 +454,7 @@ class GameUserEntryServiceImplTest {
 
         GameUserEntryRequest gameUserEntryRequest = new GameUserEntryRequest();
         gameUserEntryRequest.setPlatformIds(Collections.emptyList());
+        gameUserEntryRequest.setDownloadableContentIds(Collections.emptyList());
 
         Mockito.when(gameUserEntryRepository.save(ArgumentMatchers.any()))
                 .thenReturn(new GameUserEntry());
@@ -440,6 +509,7 @@ class GameUserEntryServiceImplTest {
 
         GameUserEntryRequest gameUserEntryRequest = new GameUserEntryRequest();
         gameUserEntryRequest.setPlatformIds(platformIds);
+        gameUserEntryRequest.setDownloadableContentIds(Collections.emptyList());
 
         Mockito.when(platformRepository.findById(ArgumentMatchers.eq(3L)))
                 .thenReturn(Optional.of(new Platform()));
@@ -449,6 +519,88 @@ class GameUserEntryServiceImplTest {
 
         // Assert
         Mockito.verify(platformRepository, Mockito.atMostOnce())
+                .findById(ArgumentMatchers.anyLong());
+
+        Mockito.verify(gameUserEntryRepository, Mockito.atMostOnce())
+                .save(ArgumentMatchers.any());
+    }
+
+    @Test
+    void update_withGameUserEntryWithNoDownloadableContents_savesGameUserEntry() {
+        // Arrange
+        Mockito.when(authenticationService.isCurrentAuthenticatedUser(ArgumentMatchers.anyLong()))
+                .thenReturn(true);
+
+        Mockito.when(gameUserEntryRepository.findById(ArgumentMatchers.anyLong()))
+                .thenReturn(Optional.of(new GameUserEntry()));
+
+        GameUserEntryRequest gameUserEntryRequest = new GameUserEntryRequest();
+        gameUserEntryRequest.setPlatformIds(Collections.emptyList());
+        gameUserEntryRequest.setDownloadableContentIds(Collections.emptyList());
+
+        Mockito.when(gameUserEntryRepository.save(ArgumentMatchers.any()))
+                .thenReturn(new GameUserEntry());
+
+        // Act
+        gameUserEntryService.update(gameUserEntryRequest);
+
+        // Assert
+        Mockito.verify(downloadableContentRepository, Mockito.never())
+                .findById(ArgumentMatchers.anyLong());
+
+        Mockito.verify(gameUserEntryRepository, Mockito.atMostOnce())
+                .save(ArgumentMatchers.any());
+    }
+
+    @Test
+    void update_withGameUserEntryWithDifferentDownloadableContents_savesGameUserEntry() {
+        // Arrange
+        Mockito.when(authenticationService.isCurrentAuthenticatedUser(ArgumentMatchers.anyLong()))
+                .thenReturn(true);
+
+        DownloadableContent downloadableContent1 = new DownloadableContent();
+        downloadableContent1.setId(1L);
+
+        GameUserEntryDownloadableContent gameUserEntryDownloadableContent1 = new GameUserEntryDownloadableContent();
+        gameUserEntryDownloadableContent1.setDownloadableContentId(downloadableContent1.getId());
+        gameUserEntryDownloadableContent1.setDownloadableContent(downloadableContent1);
+
+        DownloadableContent downloadableContent2 = new DownloadableContent();
+        downloadableContent2.setId(2L);
+
+        GameUserEntryDownloadableContent gameUserEntryDownloadableContent2 = new GameUserEntryDownloadableContent();
+        gameUserEntryDownloadableContent2.setDownloadableContentId(downloadableContent2.getId());
+        gameUserEntryDownloadableContent2.setDownloadableContent(downloadableContent2);
+
+        List<GameUserEntryDownloadableContent> downloadableContents = new ArrayList<>();
+        downloadableContents.add(gameUserEntryDownloadableContent1);
+        downloadableContents.add(gameUserEntryDownloadableContent2);
+
+        GameUserEntry gameUserEntry = new GameUserEntry();
+        gameUserEntry.setGameUserEntryDownloadableContents(downloadableContents);
+
+        Mockito.when(gameUserEntryRepository.findById(ArgumentMatchers.anyLong()))
+                .thenReturn(Optional.of(gameUserEntry));
+
+        Mockito.when(gameUserEntryRepository.save(ArgumentMatchers.any()))
+                .thenReturn(new GameUserEntry());
+
+        List<Long> downloadableContentIds = new ArrayList<>();
+        downloadableContentIds.add(1L);
+        downloadableContentIds.add(3L);
+
+        GameUserEntryRequest gameUserEntryRequest = new GameUserEntryRequest();
+        gameUserEntryRequest.setPlatformIds(Collections.emptyList());
+        gameUserEntryRequest.setDownloadableContentIds(downloadableContentIds);
+
+        Mockito.when(downloadableContentRepository.findById(ArgumentMatchers.eq(3L)))
+                .thenReturn(Optional.of(new DownloadableContent()));
+
+        // Act
+        gameUserEntryService.update(gameUserEntryRequest);
+
+        // Assert
+        Mockito.verify(downloadableContentRepository, Mockito.atMostOnce())
                 .findById(ArgumentMatchers.anyLong());
 
         Mockito.verify(gameUserEntryRepository, Mockito.atMostOnce())

--- a/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/mapper/DownloadableContentMapperTest.java
+++ b/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/mapper/DownloadableContentMapperTest.java
@@ -1,0 +1,80 @@
+package com.sparkystudios.traklibrary.game.service.mapper;
+
+import com.sparkystudios.traklibrary.game.domain.DownloadableContent;
+import com.sparkystudios.traklibrary.game.service.dto.DownloadableContentDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+class DownloadableContentMapperTest {
+
+    @Test
+    void downloadableContentToDownloadableContentDto_withNull_returnsNull() {
+        // Act
+        DownloadableContentDto result = GameMappers.DOWNLOADABLE_CONTENT_MAPPER.downloadableContentToDownloadableContentDto(null);
+
+        // Assert
+        Assertions.assertThat(result).isNull();
+    }
+
+    @Test
+    void downloadableContentToDownloadableContentDto_withDownloadableContent_mapsFields() {
+        // Arrange
+        DownloadableContent downloadableContent = new DownloadableContent();
+        downloadableContent.setId(5L);
+        downloadableContent.setName("test-name");
+        downloadableContent.setDescription("test-description");
+        downloadableContent.setReleaseDate(LocalDate.now());
+        downloadableContent.setCreatedAt(LocalDateTime.now());
+        downloadableContent.setUpdatedAt(LocalDateTime.now());
+        downloadableContent.setVersion(1L);
+
+        // Act
+        DownloadableContentDto result = GameMappers.DOWNLOADABLE_CONTENT_MAPPER.downloadableContentToDownloadableContentDto(downloadableContent);
+
+        // Assert
+        Assertions.assertThat(result.getId()).isEqualTo(downloadableContent.getId());
+        Assertions.assertThat(result.getName()).isEqualTo(downloadableContent.getName());
+        Assertions.assertThat(result.getDescription()).isEqualTo(downloadableContent.getDescription());
+        Assertions.assertThat(result.getReleaseDate()).isEqualTo(downloadableContent.getReleaseDate());
+        Assertions.assertThat(result.getCreatedAt()).isEqualTo(downloadableContent.getCreatedAt());
+        Assertions.assertThat(result.getUpdatedAt()).isEqualTo(downloadableContent.getUpdatedAt());
+        Assertions.assertThat(result.getVersion()).isEqualTo(downloadableContent.getVersion());
+    }
+
+    @Test
+    void downloadableContentDtoToDownloadableContent_withNull_returnsNull() {
+        // Act
+        DownloadableContent result = GameMappers.DOWNLOADABLE_CONTENT_MAPPER.downloadableContentDtoToDownloadableContent(null);
+
+        // Assert
+        Assertions.assertThat(result).isNull();
+    }
+
+    @Test
+    void downloadableContentDtoToDownloadableContent_withDownloadableContentDto_mapsFields() {
+        // Arrange
+        DownloadableContentDto downloadableContentDto = new DownloadableContentDto();
+        downloadableContentDto.setId(5L);
+        downloadableContentDto.setName("test-name");
+        downloadableContentDto.setDescription("test-description");
+        downloadableContentDto.setReleaseDate(LocalDate.now());
+        downloadableContentDto.setCreatedAt(LocalDateTime.now());
+        downloadableContentDto.setUpdatedAt(LocalDateTime.now());
+        downloadableContentDto.setVersion(1L);
+
+        // Act
+        DownloadableContent result = GameMappers.DOWNLOADABLE_CONTENT_MAPPER.downloadableContentDtoToDownloadableContent(downloadableContentDto);
+
+        // Assert
+        Assertions.assertThat(result.getId()).isEqualTo(downloadableContentDto.getId());
+        Assertions.assertThat(result.getName()).isEqualTo(downloadableContentDto.getName());
+        Assertions.assertThat(result.getDescription()).isEqualTo(downloadableContentDto.getDescription());
+        Assertions.assertThat(result.getReleaseDate()).isEqualTo(downloadableContentDto.getReleaseDate());
+        Assertions.assertThat(result.getCreatedAt()).isNull();
+        Assertions.assertThat(result.getUpdatedAt()).isNull();
+        Assertions.assertThat(result.getVersion()).isEqualTo(downloadableContentDto.getVersion());
+    }
+}

--- a/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/mapper/GameDetailsMapperTest.java
+++ b/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/mapper/GameDetailsMapperTest.java
@@ -35,6 +35,10 @@ class GameDetailsMapperTest {
         gameReleaseDate.setReleaseDate(LocalDate.now());
         gameReleaseDate.setVersion(1L);
 
+        DownloadableContent downloadableContent = new DownloadableContent();
+        downloadableContent.setName("test-downloadable-content");
+        downloadableContent.setReleaseDate(LocalDate.now());
+
         Franchise franchise = new Franchise();
         franchise.setTitle("franchise-title");
 
@@ -50,6 +54,7 @@ class GameDetailsMapperTest {
         game.addPlatform(platform);
         game.addPublisher(publisher);
         game.addReleaseDate(gameReleaseDate);
+        game.addDownloadableContent(downloadableContent);
         game.setFranchise(franchise);
 
         // Act
@@ -67,6 +72,7 @@ class GameDetailsMapperTest {
         Assertions.assertThat(result.getPlatforms()).hasSize(1);
         Assertions.assertThat(result.getPublishers()).hasSize(1);
         Assertions.assertThat(result.getReleaseDates()).hasSize(1);
+        Assertions.assertThat(result.getDownloadableContents()).hasSize(1);
         Assertions.assertThat(result.getFranchise().getTitle()).isEqualTo(franchise.getTitle());
     }
 }

--- a/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/mapper/GameMapperTest.java
+++ b/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/mapper/GameMapperTest.java
@@ -1,6 +1,7 @@
 package com.sparkystudios.traklibrary.game.service.mapper;
 
 import com.sparkystudios.traklibrary.game.domain.*;
+import com.sparkystudios.traklibrary.game.service.dto.DownloadableContentDto;
 import com.sparkystudios.traklibrary.game.service.dto.GameDto;
 import com.sparkystudios.traklibrary.game.service.dto.GameReleaseDateDto;
 import org.assertj.core.api.Assertions;
@@ -23,11 +24,6 @@ class GameMapperTest {
     @Test
     void gameToGameDto_withGame_mapsFields() {
         // Arrange
-        GameReleaseDate gameReleaseDate = new GameReleaseDate();
-        gameReleaseDate.setRegion(GameRegion.PAL);
-        gameReleaseDate.setReleaseDate(LocalDate.now());
-        gameReleaseDate.setVersion(1L);
-
         Game game = new Game();
         game.setId(5L);
         game.setTitle("test-title");
@@ -38,7 +34,8 @@ class GameMapperTest {
         game.setCreatedAt(LocalDateTime.now());
         game.setUpdatedAt(LocalDateTime.now());
         game.setVersion(1L);
-        game.addReleaseDate(gameReleaseDate);
+        game.addReleaseDate(new GameReleaseDate());
+        game.addDownloadableContent(new DownloadableContent());
 
         // Act
         GameDto result = GameMappers.GAME_MAPPER.gameToGameDto(game);
@@ -68,11 +65,6 @@ class GameMapperTest {
     @Test
     void gameDtoToGame_withGameDto_mapsFields() {
         // Arrange
-        GameReleaseDateDto gameReleaseDateDto = new GameReleaseDateDto();
-        gameReleaseDateDto.setRegion(GameRegion.PAL);
-        gameReleaseDateDto.setReleaseDate(LocalDate.now());
-        gameReleaseDateDto.setVersion(1L);
-
         GameDto gameDto = new GameDto();
         gameDto.setId(5L);
         gameDto.setTitle("test-title");
@@ -83,7 +75,8 @@ class GameMapperTest {
         gameDto.setCreatedAt(LocalDateTime.now());
         gameDto.setUpdatedAt(LocalDateTime.now());
         gameDto.setVersion(1L);
-        gameDto.getReleaseDates().add(gameReleaseDateDto);
+        gameDto.getReleaseDates().add(new GameReleaseDateDto());
+        gameDto.getDownloadableContents().add(new DownloadableContentDto());
 
         // Act
         Game result = GameMappers.GAME_MAPPER.gameDtoToGame(gameDto);

--- a/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/mapper/GameUserEntryDownloadableMapperTest.java
+++ b/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/mapper/GameUserEntryDownloadableMapperTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
-public class GameUserEntryDownloadableMapperTest {
+class GameUserEntryDownloadableMapperTest {
 
     @Test
     void gameUserEntryDownloadableContentToGameUserEntryDownloadableContentDto_withNull_returnsNull() {

--- a/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/mapper/GameUserEntryDownloadableMapperTest.java
+++ b/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/mapper/GameUserEntryDownloadableMapperTest.java
@@ -1,0 +1,53 @@
+package com.sparkystudios.traklibrary.game.service.mapper;
+
+import com.sparkystudios.traklibrary.game.domain.DownloadableContent;
+import com.sparkystudios.traklibrary.game.domain.GameUserEntryDownloadableContent;
+import com.sparkystudios.traklibrary.game.service.dto.GameUserEntryDownloadableContentDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+public class GameUserEntryDownloadableMapperTest {
+
+    @Test
+    void gameUserEntryDownloadableContentToGameUserEntryDownloadableContentDto_withNull_returnsNull() {
+        // Act
+        GameUserEntryDownloadableContentDto result = GameMappers.GAME_USER_ENTRY_DOWNLOADABLE_CONTENT_MAPPER
+                .gameUserEntryDownloadableContentToGameUserEntryDownloadableContentDto(null);
+
+        // Assert
+        Assertions.assertThat(result).isNull();
+    }
+
+    @Test
+    void gameUserEntryPlatformToGameUserEntryPlatformDto_withGameUserEntryPlatform_mapsFields() {
+        // Arrange
+        DownloadableContent downloadableContent = new DownloadableContent();
+        downloadableContent.setName("dlc-name");
+
+        GameUserEntryDownloadableContent gameUserEntryDownloadableContent = new GameUserEntryDownloadableContent();
+        gameUserEntryDownloadableContent.setId(1L);
+        gameUserEntryDownloadableContent.setDownloadableContentId(2L);
+        gameUserEntryDownloadableContent.setDownloadableContent(downloadableContent);
+        gameUserEntryDownloadableContent.setGameUserEntryId(3L);
+        gameUserEntryDownloadableContent.setCreatedAt(LocalDateTime.now());
+        gameUserEntryDownloadableContent.setUpdatedAt(LocalDateTime.now());
+        gameUserEntryDownloadableContent.setVersion(4L);
+
+        // Act
+        GameUserEntryDownloadableContentDto result = GameMappers.GAME_USER_ENTRY_DOWNLOADABLE_CONTENT_MAPPER
+                .gameUserEntryDownloadableContentToGameUserEntryDownloadableContentDto(gameUserEntryDownloadableContent);
+
+        // Assert
+        Assertions.assertThat(result.getId()).isEqualTo(gameUserEntryDownloadableContent.getId());
+        Assertions.assertThat(result.getDownloadableContentId()).isEqualTo(gameUserEntryDownloadableContent.getDownloadableContentId());
+        Assertions.assertThat(result.getDownloadableContentName()).isEqualTo(downloadableContent.getName());
+        Assertions.assertThat(result.getGameUserEntryId()).isEqualTo(gameUserEntryDownloadableContent.getGameUserEntryId());
+        Assertions.assertThat(result.getCreatedAt())
+                .isEqualToIgnoringNanos(gameUserEntryDownloadableContent.getCreatedAt());
+        Assertions.assertThat(result.getUpdatedAt())
+                .isEqualToIgnoringNanos(gameUserEntryDownloadableContent.getUpdatedAt());
+        Assertions.assertThat(result.getVersion()).isEqualTo(gameUserEntryDownloadableContent.getVersion());
+    }
+}

--- a/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/mapper/GameUserEntryMapperTest.java
+++ b/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/mapper/GameUserEntryMapperTest.java
@@ -28,8 +28,16 @@ class GameUserEntryMapperTest {
         game.setTitle("test-title");
         game.addPublisher(publisher);
 
+
         GameUserEntryPlatform gameUserEntryPlatform = new GameUserEntryPlatform();
         gameUserEntryPlatform.setId(1L);
+
+        DownloadableContent downloadableContent = new DownloadableContent();
+        downloadableContent.setName("test-name");
+
+        GameUserEntryDownloadableContent gameUserEntryDownloadableContent = new GameUserEntryDownloadableContent();
+        gameUserEntryDownloadableContent.setId(2L);
+        gameUserEntryDownloadableContent.setDownloadableContent(downloadableContent);
 
         GameUserEntry gameUserEntry = new GameUserEntry();
         gameUserEntry.setId(5L);
@@ -41,6 +49,7 @@ class GameUserEntryMapperTest {
         gameUserEntry.setCreatedAt(LocalDateTime.now());
         gameUserEntry.setUpdatedAt(LocalDateTime.now());
         gameUserEntry.addGameUserEntryPlatform(gameUserEntryPlatform);
+        gameUserEntry.addGameUserEntryDownloadableContent(gameUserEntryDownloadableContent);
 
         // Act
         GameUserEntryDto result = GameMappers.GAME_USER_ENTRY_MAPPER.gameUserEntryToGameUserEntryDto(gameUserEntry);
@@ -57,6 +66,9 @@ class GameUserEntryMapperTest {
         Assertions.assertThat(result.getGameUserEntryPlatforms()).hasSize(1);
         Assertions.assertThat(result.getGameUserEntryPlatforms().iterator().next().getId())
                 .isEqualTo(gameUserEntryPlatform.getId());
+        Assertions.assertThat(result.getGameUserEntryDownloadableContents()).hasSize(1);
+        Assertions.assertThat(result.getGameUserEntryDownloadableContents().iterator().next().getId())
+                .isEqualTo(gameUserEntryDownloadableContent.getId());
         Assertions.assertThat(result.getCreatedAt()).isEqualTo(gameUserEntry.getCreatedAt());
         Assertions.assertThat(result.getUpdatedAt()).isEqualTo(gameUserEntry.getUpdatedAt());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -358,6 +358,12 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                </configuration>
+            </plugin>
         </plugins>
 
         <pluginManagement>


### PR DESCRIPTION
- Added new tables to define DLC for a given game and which DLC a user has with the game_user_entry_dlc table.
- Added DTO's and repositories for the new entities.
- Ensured that when creating a new game or updating an existing one, it takes the DLC into consideration when persisting.
- Added additional validation when creating a new user account.
- Changed the docker-compose file to use the new name of the docker images.
- Added unit tests for all new functionality.
- Added the surefire plugin to reduce the amount of redundant information being logged during the maven test phase.
- 