### PR TITLE
APP-33: Added support for multiple images for games.

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -2,7 +2,7 @@ version: '3.3'
 services:
   db:
     container_name: traklibrary-db
-    image: postgres:9.6
+    image: postgres:13.2
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password

--- a/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/Game.java
+++ b/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/Game.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
@@ -96,6 +98,11 @@ public class Game {
     @ToString.Exclude
     @OneToMany(mappedBy = "game", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     private Set<DownloadableContent> downloadableContents = new TreeSet<>();
+
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    @OneToMany(mappedBy = "game", fetch = FetchType.LAZY)
+    private Collection<GameImage> images = new ArrayList<>();
 
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreatedDate

--- a/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/GameImage.java
+++ b/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/GameImage.java
@@ -33,6 +33,9 @@ public class GameImage {
     @Column(name = "filename", updatable = false)
     private String filename;
 
+    @Column(name = "size", nullable = false)
+    private GameImageSize imageSize;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreatedDate
     private LocalDateTime createdAt;

--- a/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/GameImageSize.java
+++ b/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/GameImageSize.java
@@ -1,0 +1,15 @@
+package com.sparkystudios.traklibrary.game.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GameImageSize {
+
+    SMALL((short)0),
+    MEDIUM((short)1),
+    LARGE((short)2);
+
+    private final short id;
+}

--- a/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/converter/GameImageSizeAttributeConverter.java
+++ b/game-domain/src/main/java/com/sparkystudios/traklibrary/game/domain/converter/GameImageSizeAttributeConverter.java
@@ -1,0 +1,29 @@
+package com.sparkystudios.traklibrary.game.domain.converter;
+
+import com.sparkystudios.traklibrary.game.domain.GameImageSize;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+@Converter(autoApply = true)
+public class GameImageSizeAttributeConverter implements AttributeConverter<GameImageSize, Short> {
+
+    @Override
+    public Short convertToDatabaseColumn(GameImageSize gameImageSize) {
+        return Objects.requireNonNullElse(gameImageSize, GameImageSize.SMALL).getId();
+    }
+
+    @Override
+    public GameImageSize convertToEntityAttribute(Short gameImageSizeId) {
+        if (gameImageSizeId == null) {
+            return GameImageSize.SMALL;
+        }
+
+        return Stream.of(GameImageSize.values())
+                .filter(ag -> ag.getId() == gameImageSizeId)
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+    }
+}

--- a/game-domain/src/main/resources/db/changelog/001-initial.xml
+++ b/game-domain/src/main/resources/db/changelog/001-initial.xml
@@ -441,6 +441,9 @@
             <column name="filename" type="varchar(255)">
                 <constraints nullable="false"/>
             </column>
+            <column name="size" type="smallint">
+                <constraints nullable="false" />
+            </column>
             <column name="created_at" type="TIMESTAMP WITHOUT TIME ZONE" defaultValueComputed="CURRENT_TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
@@ -459,8 +462,8 @@
         <!-- game_image unique constraints -->
         <addUniqueConstraint
                 tableName="game_image"
-                columnNames="game_id"
-                constraintName="unq_game_image_game_id" />
+                columnNames="game_id,size"
+                constraintName="unq_game_image_game_id_size" />
 
         <!-- Create the game_barcode table -->
         <createTable tableName="game_barcode">

--- a/game-domain/src/test/java/com/sparkystudios/traklibrary/game/domain/GameImageTest.java
+++ b/game-domain/src/test/java/com/sparkystudios/traklibrary/game/domain/GameImageTest.java
@@ -38,6 +38,7 @@ class GameImageTest {
         GameImage gameImage = new GameImage();
         gameImage.setGameId(game.getId());
         gameImage.setFilename("filename.png");
+        gameImage.setImageSize(GameImageSize.MEDIUM);
 
         // Act
         GameImage result = testEntityManager.persistFlushFind(gameImage);

--- a/game-domain/src/test/java/com/sparkystudios/traklibrary/game/domain/converter/GameImageSizeAttributeConverterTest.java
+++ b/game-domain/src/test/java/com/sparkystudios/traklibrary/game/domain/converter/GameImageSizeAttributeConverterTest.java
@@ -1,0 +1,53 @@
+package com.sparkystudios.traklibrary.game.domain.converter;
+
+import com.sparkystudios.traklibrary.game.domain.GameImageSize;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class GameImageSizeAttributeConverterTest {
+
+    @Test
+    void convertToDatabaseColumn_withNullGameImageSize_returnsSmallId() {
+        // Act
+        Short result = new GameImageSizeAttributeConverter().convertToDatabaseColumn(null);
+
+        // Assert
+        Assertions.assertEquals(GameImageSize.SMALL.getId(), result, "If null is provided, it should default to the id of SMALL.");
+    }
+
+    @Test
+    void convertToDatabaseColumn_withValidGameImageSize_returnsIdOfGameImageSize() {
+        // Act
+        Short result = new GameImageSizeAttributeConverter().convertToDatabaseColumn(GameImageSize.LARGE);
+
+        // Assert
+        Assertions.assertEquals(GameImageSize.LARGE.getId(), result, "The id should match the GameImageSize provided.");
+    }
+
+    @Test
+    void convertToEntityAttribute_withNullId_returnsAgeRatingPending() {
+        // Act
+        GameImageSize result = new GameImageSizeAttributeConverter().convertToEntityAttribute(null);
+
+        // Assert
+        Assertions.assertEquals(GameImageSize.SMALL, result, "If null is provided, it should default to SMALL.");
+    }
+
+    @Test
+    void convertToEntityAttribute_withInvalidId_throwsIllegalArgumentException() {
+        // Arrange
+        GameImageSizeAttributeConverter converter = new GameImageSizeAttributeConverter();
+
+        // Assert
+        Assertions.assertThrows(IllegalArgumentException.class, () -> converter.convertToEntityAttribute((short)1000));
+    }
+
+    @Test
+    void convertToEntityAttribute_withValidGameSizeImageId_returnsCorrectAgeRating() {
+        // Act
+        GameImageSize result = new GameImageSizeAttributeConverter().convertToEntityAttribute(GameImageSize.MEDIUM.getId());
+
+        // Assert
+        Assertions.assertEquals(GameImageSize.MEDIUM, result, "The GameImageSize should match the id provided.");
+    }
+}

--- a/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/GameImageRepository.java
+++ b/game-repository/src/main/java/com/sparkystudios/traklibrary/game/repository/GameImageRepository.java
@@ -1,6 +1,7 @@
 package com.sparkystudios.traklibrary.game.repository;
 
 import com.sparkystudios.traklibrary.game.domain.GameImage;
+import com.sparkystudios.traklibrary.game.domain.GameImageSize;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,7 +10,7 @@ import java.util.Optional;
 @Repository
 public interface GameImageRepository extends PagingAndSortingRepository<GameImage, Long> {
 
-    boolean existsByGameId(long gameId);
+    boolean existsByGameIdAndImageSize(long gameId, GameImageSize gameImageSize);
 
-    Optional<GameImage> findByGameId(long gameId);
+    Optional<GameImage> findByGameIdAndImageSize(long gameId, GameImageSize gameImageSize);
 }

--- a/game-repository/src/test/java/com/sparkystudios/traklibrary/game/repository/GameImageRepositoryTest.java
+++ b/game-repository/src/test/java/com/sparkystudios/traklibrary/game/repository/GameImageRepositoryTest.java
@@ -3,6 +3,7 @@ package com.sparkystudios.traklibrary.game.repository;
 import com.sparkystudios.traklibrary.game.domain.AgeRating;
 import com.sparkystudios.traklibrary.game.domain.Game;
 import com.sparkystudios.traklibrary.game.domain.GameImage;
+import com.sparkystudios.traklibrary.game.domain.GameImageSize;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,16 +22,16 @@ class GameImageRepositoryTest {
     private GameRepository gameRepository;
 
     @Test
-    void existsByGameId_withNonExistentGame_returnsFalse() {
+    void existsByGameIdAndImageSize_withNonExistentGameAndGameImageSize_returnsFalse() {
         // Act
-        boolean result = gameImageRepository.existsByGameId(1L);
+        boolean result = gameImageRepository.existsByGameIdAndImageSize(1L, GameImageSize.SMALL);
 
         // Assert
         Assertions.assertThat(result).isFalse();
     }
 
     @Test
-    void existsByGameId_withGame_returnsTrue() {
+    void existsByGameIdAndImageSize_withGameAndGameImageSize_returnsTrue() {
         // Arrange
         Game game = new Game();
         game.setTitle("game-title");
@@ -41,26 +42,27 @@ class GameImageRepositoryTest {
         GameImage gameImage = new GameImage();
         gameImage.setGameId(game.getId());
         gameImage.setFilename("filename.png");
+        gameImage.setImageSize(GameImageSize.MEDIUM);
         gameImageRepository.save(gameImage);
 
         // Act
-        boolean result = gameImageRepository.existsByGameId(game.getId());
+        boolean result = gameImageRepository.existsByGameIdAndImageSize(game.getId(), GameImageSize.MEDIUM);
 
         // Assert
         Assertions.assertThat(result).isTrue();
     }
 
     @Test
-    void findByGameId_withNonExistentGameImage_returnsEmptyOptional() {
+    void findByGameIdAndImageSize_withNonExistentGameImage_returnsEmptyOptional() {
         // Act
-        Optional<GameImage> result = gameImageRepository.findByGameId(1L);
+        Optional<GameImage> result = gameImageRepository.findByGameIdAndImageSize(1L, GameImageSize.SMALL);
 
         // Assert
         Assertions.assertThat(result).isEmpty();
     }
 
     @Test
-    void findByGameId_withGameImage_returnsGameImage() {
+    void findByGameIdAndImageSize_withGameImage_returnsGameImage() {
         // Arrange
         Game game = new Game();
         game.setTitle("game-title");
@@ -71,10 +73,11 @@ class GameImageRepositoryTest {
         GameImage gameImage = new GameImage();
         gameImage.setGameId(game.getId());
         gameImage.setFilename("filename.png");
+        gameImage.setImageSize(GameImageSize.SMALL);
         gameImageRepository.save(gameImage);
 
         // Act
-        Optional<GameImage> result = gameImageRepository.findByGameId(game.getId());
+        Optional<GameImage> result = gameImageRepository.findByGameIdAndImageSize(game.getId(), GameImageSize.SMALL);
 
         // Assert
         Assertions.assertThat(result).isNotEmpty();

--- a/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/adapter/GameServerSecurityConfigurerAdapter.java
+++ b/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/adapter/GameServerSecurityConfigurerAdapter.java
@@ -33,7 +33,7 @@ public class GameServerSecurityConfigurerAdapter extends WebSecurityConfigurerAd
     protected void configure(HttpSecurity http) throws Exception {
 
         List<RequestMatcher> pathsToSkip = Collections.singletonList(
-                new AntPathRequestMatcher("/**/image", HttpMethod.GET.name()));
+                new AntPathRequestMatcher("/**/images/**", HttpMethod.GET.name()));
 
         SkipPathRequestMatcher skipPathRequestMatcher = new SkipPathRequestMatcher(pathsToSkip, "/**");
         JwtAuthenticationProcessingFilter jwtAuthenticationProcessingFilter =
@@ -41,7 +41,7 @@ public class GameServerSecurityConfigurerAdapter extends WebSecurityConfigurerAd
 
         http
                 .authorizeRequests()
-                .antMatchers(HttpMethod.GET, "/**/image").permitAll()
+                .antMatchers(HttpMethod.GET, "/**/images/**").permitAll()
                 .anyRequest()
                 .authenticated()
                 .and()

--- a/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/assembler/GameDetailsRepresentationModelAssembler.java
+++ b/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/assembler/GameDetailsRepresentationModelAssembler.java
@@ -2,6 +2,7 @@ package com.sparkystudios.traklibrary.game.server.assembler;
 
 import com.sparkystudios.traklibrary.game.server.controller.FranchiseController;
 import com.sparkystudios.traklibrary.game.server.controller.GameController;
+import com.sparkystudios.traklibrary.game.server.controller.GameImageController;
 import com.sparkystudios.traklibrary.game.service.dto.GameDetailsDto;
 import com.sparkystudios.traklibrary.game.service.dto.GameUserEntryDto;
 import lombok.RequiredArgsConstructor;
@@ -32,8 +33,14 @@ public class GameDetailsRepresentationModelAssembler implements SimpleRepresenta
             resource.add(WebMvcLinkBuilder.linkTo(methodOn(GameController.class).findGameDetailsByGameId(content.getId()))
                     .withSelfRel());
 
-            resource.add(linkTo(methodOn(GameController.class).findGameImageByGameId(content.getId()))
-                    .withRel("image"));
+            resource.add(linkTo(methodOn(GameImageController.class).findGameImageByGameIdAndImageSizeSmall(content.getId()))
+                    .withRel("small_image"));
+
+            resource.add(linkTo(methodOn(GameImageController.class).findGameImageByGameIdAndImageSizeMedium(content.getId()))
+                    .withRel("medium_image"));
+
+            resource.add(linkTo(methodOn(GameImageController.class).findGameImageByGameIdAndImageSizeLarge(content.getId()))
+                    .withRel("large_image"));
 
             resource.add(linkTo(methodOn(GameController.class).findPlatformsByGameId(content.getId()))
                     .withRel("platforms"));

--- a/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/assembler/GameRepresentationModelAssembler.java
+++ b/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/assembler/GameRepresentationModelAssembler.java
@@ -2,6 +2,7 @@ package com.sparkystudios.traklibrary.game.server.assembler;
 
 import com.sparkystudios.traklibrary.game.server.controller.FranchiseController;
 import com.sparkystudios.traklibrary.game.server.controller.GameController;
+import com.sparkystudios.traklibrary.game.server.controller.GameImageController;
 import com.sparkystudios.traklibrary.game.service.dto.GameDto;
 import com.sparkystudios.traklibrary.game.service.dto.GameUserEntryDto;
 import lombok.RequiredArgsConstructor;
@@ -32,8 +33,14 @@ public class GameRepresentationModelAssembler implements SimpleRepresentationMod
             resource.add(WebMvcLinkBuilder.linkTo(methodOn(GameController.class).findById(content.getId()))
                     .withSelfRel());
 
-            resource.add(linkTo(methodOn(GameController.class).findGameImageByGameId(content.getId()))
-                    .withRel("image"));
+            resource.add(linkTo(methodOn(GameImageController.class).findGameImageByGameIdAndImageSizeSmall(content.getId()))
+                    .withRel("small_image"));
+
+            resource.add(linkTo(methodOn(GameImageController.class).findGameImageByGameIdAndImageSizeMedium(content.getId()))
+                    .withRel("medium_image"));
+
+            resource.add(linkTo(methodOn(GameImageController.class).findGameImageByGameIdAndImageSizeLarge(content.getId()))
+                    .withRel("large_image"));
 
             resource.add(linkTo(methodOn(GameController.class).findPlatformsByGameId(content.getId()))
                     .withRel("platforms"));

--- a/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/assembler/GameUserEntryRepresentationModelAssembler.java
+++ b/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/assembler/GameUserEntryRepresentationModelAssembler.java
@@ -1,6 +1,7 @@
 package com.sparkystudios.traklibrary.game.server.assembler;
 
 import com.sparkystudios.traklibrary.game.server.controller.GameController;
+import com.sparkystudios.traklibrary.game.server.controller.GameImageController;
 import com.sparkystudios.traklibrary.game.server.controller.GameUserEntryController;
 import com.sparkystudios.traklibrary.game.service.dto.GameUserEntryDto;
 import org.springframework.hateoas.CollectionModel;
@@ -27,8 +28,12 @@ public class GameUserEntryRepresentationModelAssembler implements SimpleRepresen
                     .withRel("game"));
             resource.add(linkTo(methodOn(GameController.class).findGameDetailsByGameId(content.getGameId()))
                     .withRel("game_details"));
-            resource.add(linkTo(methodOn(GameController.class).findGameImageByGameId(content.getGameId()))
-                    .withRel("image"));
+            resource.add(linkTo(methodOn(GameImageController.class).findGameImageByGameIdAndImageSizeSmall(content.getId()))
+                    .withRel("small_image"));
+            resource.add(linkTo(methodOn(GameImageController.class).findGameImageByGameIdAndImageSizeMedium(content.getId()))
+                    .withRel("medium_image"));
+            resource.add(linkTo(methodOn(GameImageController.class).findGameImageByGameIdAndImageSizeLarge(content.getId()))
+                    .withRel("large_image"));
         }
     }
 

--- a/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/controller/GameImageController.java
+++ b/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/controller/GameImageController.java
@@ -1,0 +1,136 @@
+package com.sparkystudios.traklibrary.game.server.controller;
+
+import com.sparkystudios.traklibrary.game.domain.GameImage;
+import com.sparkystudios.traklibrary.game.domain.GameImageSize;
+import com.sparkystudios.traklibrary.game.service.GameImageService;
+import com.sparkystudios.traklibrary.game.service.GameService;
+import com.sparkystudios.traklibrary.game.service.dto.GameDto;
+import com.sparkystudios.traklibrary.game.service.dto.ImageDataDto;
+import com.sparkystudios.traklibrary.security.annotation.AllowedForAdmin;
+import com.sparkystudios.traklibrary.security.exception.ApiError;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * The {@link GameImageController} is a simple controller class that exposes an API that is used to upload and download images for
+ * different games at different sizes/dimensions. It provides API end-points for uploading and downloading images (with each size given
+ * an individual end-point). It should be noted that the controller itself contains very little logic, the logic is contained within the
+ * {@link GameImageService}. The controllers primary purpose is to wrap the responses it received from the {@link GameImageService}
+ * into byte arrays. All mappings on this controller therefore produce a application/octet-stream response.
+ *
+ * @since 0.1.0
+ * @author Sparky Studios
+ */
+@RequiredArgsConstructor
+@RestController
+@RequestMapping(value = "/{id}/images", produces = "application/vnd.traklibrary.v1.hal+json")
+public class GameImageController {
+
+    private final GameImageService gameImageService;
+
+    /**
+     * End-point that create a {@link GameImage} instance and register
+     * the specified file with the chosen image provider. If the file is in a incorrect format or a
+     * image already exists for the given {@link GameDto}, an exception will be thrown and an {@link ApiError}
+     * will be returned to the callee.
+     *
+     * {@link GameImage}'s can only be created for users with admin privileges.
+     *
+     * @param id The ID of the {@link GameDto} to persist and image for.
+     * @param gameImageSize The size of the image to upload.
+     * @param file The {@link MultipartFile} containing the image to upload.
+     */
+    @AllowedForAdmin
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public void saveGameImageForGameIdAndGameImageSize(@PathVariable long id,
+                                                       @RequestParam("image-size") GameImageSize gameImageSize,
+                                                       @RequestPart MultipartFile file) {
+        gameImageService.upload(id, gameImageSize, file);
+    }
+
+    /**
+     * End-point that will retrieve a {@link ByteArrayResource} for the image that is associated with the given
+     * {@link GameDto} ID and is assigned that image size of {@link GameImageSize#SMALL}. If no image is
+     * associated with the {@link GameDto} or it fails to retrieve the data, an empty {@link ByteArrayResource}
+     * will be returned and the error will be logged.
+     *
+     * This end-point can be called anonymously by anyone without providing any authentication or credentials.
+     *
+     * @param id The ID of the {@link GameDto} to retrieve the associated image for.
+     *
+     * @return A {@link ByteArrayResource} representing the byte information of the image file.
+     */
+    @GetMapping(value = "/small", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    public ResponseEntity<ByteArrayResource> findGameImageByGameIdAndImageSizeSmall(@PathVariable long id) {
+        // Get the image data, all images are stored as *.png so it's safe to assume the file extension.
+        ImageDataDto imageDataDto = gameImageService.download(id, GameImageSize.SMALL);
+
+        return ResponseEntity
+                .ok()
+                .contentLength(imageDataDto.getContent().length)
+                .header("Content-Disposition", "attachment; filename=\"" + imageDataDto.getFilename() + "\"")
+                .body(new ByteArrayResource(imageDataDto.getContent()));
+    }
+
+    /**
+     * End-point that will retrieve a {@link ByteArrayResource} for the image that is associated with the given
+     * {@link GameDto} ID and is assigned that image size of {@link GameImageSize#MEDIUM}. If no image is
+     * associated with the {@link GameDto} or it fails to retrieve the data, an empty {@link ByteArrayResource}
+     * will be returned and the error will be logged.
+     *
+     * This end-point can be called anonymously by anyone without providing any authentication or credentials.
+     *
+     * @param id The ID of the {@link GameDto} to retrieve the associated image for.
+     *
+     * @return A {@link ByteArrayResource} representing the byte information of the image file.
+     */
+    @GetMapping(value = "/medium", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    public ResponseEntity<ByteArrayResource> findGameImageByGameIdAndImageSizeMedium(@PathVariable long id) {
+        // Get the image data, all images are stored as *.png so it's safe to assume the file extension.
+        ImageDataDto imageDataDto = gameImageService.download(id, GameImageSize.MEDIUM);
+
+        return ResponseEntity
+                .ok()
+                .contentLength(imageDataDto.getContent().length)
+                .header("Content-Disposition", "attachment; filename=\"" + imageDataDto.getFilename() + "\"")
+                .body(new ByteArrayResource(imageDataDto.getContent()));
+    }
+
+    /**
+     * End-point that will retrieve a {@link ByteArrayResource} for the image that is associated with the given
+     * {@link GameDto} ID and is assigned that image size of {@link GameImageSize#LARGE}. If no image is
+     * associated with the {@link GameDto} or it fails to retrieve the data, an empty {@link ByteArrayResource}
+     * will be returned and the error will be logged.
+     *
+     * This end-point can be called anonymously by anyone without providing any authentication or credentials.
+     *
+     * @param id The ID of the {@link GameDto} to retrieve the associated image for.
+     *
+     * @return A {@link ByteArrayResource} representing the byte information of the image file.
+     */
+    @GetMapping(value = "/large", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    public ResponseEntity<ByteArrayResource> findGameImageByGameIdAndImageSizeLarge(@PathVariable long id) {
+        // Get the image data, all images are stored as *.png so it's safe to assume the file extension.
+        ImageDataDto imageDataDto = gameImageService.download(id, GameImageSize.LARGE);
+
+        return ResponseEntity
+                .ok()
+                .contentLength(imageDataDto.getContent().length)
+                .header("Content-Disposition", "attachment; filename=\"" + imageDataDto.getFilename() + "\"")
+                .body(new ByteArrayResource(imageDataDto.getContent()));
+    }
+}

--- a/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/controller/GameImageController.java
+++ b/game-server/src/main/java/com/sparkystudios/traklibrary/game/server/controller/GameImageController.java
@@ -3,14 +3,12 @@ package com.sparkystudios.traklibrary.game.server.controller;
 import com.sparkystudios.traklibrary.game.domain.GameImage;
 import com.sparkystudios.traklibrary.game.domain.GameImageSize;
 import com.sparkystudios.traklibrary.game.service.GameImageService;
-import com.sparkystudios.traklibrary.game.service.GameService;
 import com.sparkystudios.traklibrary.game.service.dto.GameDto;
 import com.sparkystudios.traklibrary.game.service.dto.ImageDataDto;
 import com.sparkystudios.traklibrary.security.annotation.AllowedForAdmin;
 import com.sparkystudios.traklibrary.security.exception.ApiError;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.ByteArrayResource;
-import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -78,12 +76,7 @@ public class GameImageController {
     public ResponseEntity<ByteArrayResource> findGameImageByGameIdAndImageSizeSmall(@PathVariable long id) {
         // Get the image data, all images are stored as *.png so it's safe to assume the file extension.
         ImageDataDto imageDataDto = gameImageService.download(id, GameImageSize.SMALL);
-
-        return ResponseEntity
-                .ok()
-                .contentLength(imageDataDto.getContent().length)
-                .header("Content-Disposition", "attachment; filename=\"" + imageDataDto.getFilename() + "\"")
-                .body(new ByteArrayResource(imageDataDto.getContent()));
+        return getImageDataAsByteArrayResource(imageDataDto.getFilename(), imageDataDto.getContent());
     }
 
     /**
@@ -102,12 +95,7 @@ public class GameImageController {
     public ResponseEntity<ByteArrayResource> findGameImageByGameIdAndImageSizeMedium(@PathVariable long id) {
         // Get the image data, all images are stored as *.png so it's safe to assume the file extension.
         ImageDataDto imageDataDto = gameImageService.download(id, GameImageSize.MEDIUM);
-
-        return ResponseEntity
-                .ok()
-                .contentLength(imageDataDto.getContent().length)
-                .header("Content-Disposition", "attachment; filename=\"" + imageDataDto.getFilename() + "\"")
-                .body(new ByteArrayResource(imageDataDto.getContent()));
+        return getImageDataAsByteArrayResource(imageDataDto.getFilename(), imageDataDto.getContent());
     }
 
     /**
@@ -126,11 +114,14 @@ public class GameImageController {
     public ResponseEntity<ByteArrayResource> findGameImageByGameIdAndImageSizeLarge(@PathVariable long id) {
         // Get the image data, all images are stored as *.png so it's safe to assume the file extension.
         ImageDataDto imageDataDto = gameImageService.download(id, GameImageSize.LARGE);
+        return getImageDataAsByteArrayResource(imageDataDto.getFilename(), imageDataDto.getContent());
+    }
 
+    private ResponseEntity<ByteArrayResource> getImageDataAsByteArrayResource(String filename, byte[] imageData) {
         return ResponseEntity
                 .ok()
-                .contentLength(imageDataDto.getContent().length)
-                .header("Content-Disposition", "attachment; filename=\"" + imageDataDto.getFilename() + "\"")
-                .body(new ByteArrayResource(imageDataDto.getContent()));
+                .contentLength(imageData.length)
+                .header("Content-Disposition", "attachment; filename=\"" + filename+ "\"")
+                .body(new ByteArrayResource(imageData));
     }
 }

--- a/game-server/src/main/resources/i18n/exception.properties
+++ b/game-server/src/main/resources/i18n/exception.properties
@@ -12,7 +12,7 @@ game.exception.not-found=Unable to find Game with parameter: id={0}
 
 game-barcode.exception.barcode-not-found=No Game Barcode exists with parameter: barcode={0}
 
-game-image.exception.image-exists=Cannot save a new Game Image for a Game over an existing one. Game ID already exists: id={0}
+game-image.exception.image-exists=Cannot save a new Game Image with size {0} for Game ID: {1} over an existing one.
 game-image.exception.not-found=Cannot find Game Image with parameter: game-id={0}
 game-image.exception.upload-failed=Failed to upload a Game Image for Game: id={0}
 

--- a/game-server/src/main/resources/i18n/exception_en.properties
+++ b/game-server/src/main/resources/i18n/exception_en.properties
@@ -12,7 +12,7 @@ game.exception.not-found=Unable to find Game with parameter: id={0}
 
 game-barcode.exception.barcode-not-found=No Game Barcode exists with parameter: barcode={0}
 
-game-image.exception.image-exists=Cannot save a new Game Image for a Game over an existing one. Game ID already exists: id={0}
+game-image.exception.image-exists=Cannot save a new Game Image with size {0} for Game ID: {1} over an existing one.
 game-image.exception.not-found=Cannot find Game Image with parameter: game-id={0}
 game-image.exception.upload-failed=Failed to upload a Game Image for Game: id={0}
 

--- a/game-server/src/test/java/com/sparkystudios/traklibrary/game/server/controller/GameControllerTest.java
+++ b/game-server/src/test/java/com/sparkystudios/traklibrary/game/server/controller/GameControllerTest.java
@@ -3,13 +3,31 @@ package com.sparkystudios.traklibrary.game.server.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparkystudios.traklibrary.game.domain.AgeRating;
 import com.sparkystudios.traklibrary.game.domain.GameUserEntryStatus;
-import com.sparkystudios.traklibrary.game.server.assembler.*;
+import com.sparkystudios.traklibrary.game.server.assembler.DeveloperRepresentationModelAssembler;
+import com.sparkystudios.traklibrary.game.server.assembler.GameDetailsRepresentationModelAssembler;
+import com.sparkystudios.traklibrary.game.server.assembler.GameRepresentationModelAssembler;
+import com.sparkystudios.traklibrary.game.server.assembler.GameUserEntryRepresentationModelAssembler;
+import com.sparkystudios.traklibrary.game.server.assembler.GenreRepresentationModelAssembler;
+import com.sparkystudios.traklibrary.game.server.assembler.PlatformRepresentationModelAssembler;
+import com.sparkystudios.traklibrary.game.server.assembler.PublisherRepresentationModelAssembler;
 import com.sparkystudios.traklibrary.game.server.configuration.TrakHalJsonMediaTypeConfiguration;
 import com.sparkystudios.traklibrary.game.server.converter.JsonMergePatchHttpMessageConverter;
 import com.sparkystudios.traklibrary.game.server.exception.GlobalExceptionHandler;
 import com.sparkystudios.traklibrary.game.server.utils.ResponseVerifier;
-import com.sparkystudios.traklibrary.game.service.*;
-import com.sparkystudios.traklibrary.game.service.dto.*;
+import com.sparkystudios.traklibrary.game.service.DeveloperService;
+import com.sparkystudios.traklibrary.game.service.GameDetailsService;
+import com.sparkystudios.traklibrary.game.service.GameService;
+import com.sparkystudios.traklibrary.game.service.GameUserEntryService;
+import com.sparkystudios.traklibrary.game.service.GenreService;
+import com.sparkystudios.traklibrary.game.service.PlatformService;
+import com.sparkystudios.traklibrary.game.service.PublisherService;
+import com.sparkystudios.traklibrary.game.service.dto.DeveloperDto;
+import com.sparkystudios.traklibrary.game.service.dto.GameDetailsDto;
+import com.sparkystudios.traklibrary.game.service.dto.GameDto;
+import com.sparkystudios.traklibrary.game.service.dto.GameUserEntryDto;
+import com.sparkystudios.traklibrary.game.service.dto.GenreDto;
+import com.sparkystudios.traklibrary.game.service.dto.PlatformDto;
+import com.sparkystudios.traklibrary.game.service.dto.PublisherDto;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
@@ -24,7 +42,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -67,9 +84,6 @@ class GameControllerTest {
 
     @MockBean
     private GameUserEntryService gameUserEntryService;
-
-    @MockBean
-    private GameImageService gameImageService;
 
     @TestConfiguration
     static class TestConfig {
@@ -153,41 +167,6 @@ class GameControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isCreated());
 
         ResponseVerifier.verifyGameDto("", resultActions, gameDto);
-    }
-
-    @Test
-    void saveGameImageForGameId_withInvalidFileData_returns400() throws Exception {
-        // Act
-        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.multipart("/1/image")
-                .contentType(MediaType.MULTIPART_FORM_DATA)
-                .accept("application/vnd.traklibrary.v1.hal+json"));
-
-        // Assert
-        resultActions
-                .andExpect(MockMvcResultMatchers.status().isBadRequest())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.status", Matchers.is(HttpStatus.BAD_REQUEST.name())))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.time").exists())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.error").exists())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.details").exists());
-    }
-
-    @Test
-    void saveGameImageForGameId_withValidFileData_returns204() throws Exception {
-        // Arrange
-        MockMultipartFile file = new MockMultipartFile("file", "filename.txt", "text/plain", "some xml".getBytes());
-
-        Mockito.doNothing()
-                .when(gameImageService).upload(ArgumentMatchers.anyLong(), ArgumentMatchers.any());
-
-        // Act
-        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.multipart("/1/image")
-                .file(file)
-                .contentType(MediaType.MULTIPART_FORM_DATA)
-                .accept("application/vnd.traklibrary.v1.hal+json"));
-
-        // Assert
-        resultActions
-                .andExpect(MockMvcResultMatchers.status().isNoContent());
     }
 
     @Test
@@ -902,25 +881,6 @@ class GameControllerTest {
 
         ResponseVerifier.verifyGameUserEntryDto("._embedded.data[0]", resultActions);
         ResponseVerifier.verifyGameUserEntryDto("._embedded.data[1]", resultActions);
-    }
-
-    @Test
-    void findGameImageByGameId_withValidId_returns200() throws Exception {
-        // Arrange
-        ImageDataDto imageDataDto = new ImageDataDto();
-        imageDataDto.setContent(new byte[] { 'a', 'b' });
-        imageDataDto.setFilename("filename.png");
-
-        Mockito.when(gameImageService.download(ArgumentMatchers.anyLong()))
-                .thenReturn(imageDataDto);
-
-        // Act
-        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/1/image")
-                .accept(MediaType.APPLICATION_OCTET_STREAM_VALUE));
-
-        // Assert
-        resultActions
-                .andExpect(MockMvcResultMatchers.status().isOk());
     }
 
     @Test

--- a/game-server/src/test/java/com/sparkystudios/traklibrary/game/server/controller/GameImageControllerTest.java
+++ b/game-server/src/test/java/com/sparkystudios/traklibrary/game/server/controller/GameImageControllerTest.java
@@ -1,0 +1,133 @@
+package com.sparkystudios.traklibrary.game.server.controller;
+
+import com.sparkystudios.traklibrary.game.domain.GameImageSize;
+import com.sparkystudios.traklibrary.game.server.configuration.TrakHalJsonMediaTypeConfiguration;
+import com.sparkystudios.traklibrary.game.server.converter.JsonMergePatchHttpMessageConverter;
+import com.sparkystudios.traklibrary.game.server.exception.GlobalExceptionHandler;
+import com.sparkystudios.traklibrary.game.service.GameImageService;
+import com.sparkystudios.traklibrary.game.service.dto.ImageDataDto;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@Import({GameImageController.class, TrakHalJsonMediaTypeConfiguration.class, GlobalExceptionHandler.class, JsonMergePatchHttpMessageConverter.class})
+@WebMvcTest(controllers = GameImageController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class, useDefaultFilters = false)
+@AutoConfigureMockMvc(addFilters = false)
+class GameImageControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private GameImageService gameImageService;
+
+    @Test
+    void saveGameImageForGameIdAndGameImageSize_withInvalidFileData_returns400() throws Exception {
+        // Act
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.multipart("/1/images")
+                .param("image-size", GameImageSize.SMALL.name())
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .accept("application/vnd.traklibrary.v1.hal+json"));
+
+        // Assert
+        resultActions
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.status", Matchers.is(HttpStatus.BAD_REQUEST.name())))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.time").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.error").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.details").exists());
+    }
+
+
+    @Test
+    void saveGameImageForGameIdAndGameImageSize_withValidFileData_returns204() throws Exception {
+        // Arrange
+        MockMultipartFile file = new MockMultipartFile("file", "filename.txt", "text/plain", "some xml".getBytes());
+
+        Mockito.doNothing()
+                .when(gameImageService).upload(ArgumentMatchers.anyLong(), ArgumentMatchers.any(), ArgumentMatchers.any());
+
+        // Act
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.multipart("/1/images")
+                .file(file)
+                .param("image-size", GameImageSize.SMALL.name())
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .accept("application/vnd.traklibrary.v1.hal+json"));
+
+        // Assert
+        resultActions
+                .andExpect(MockMvcResultMatchers.status().isNoContent());
+    }
+
+    @Test
+    void findGameImageByGameIdAndImageSizeSmall_withValidId_returns200() throws Exception {
+        // Arrange
+        ImageDataDto imageDataDto = new ImageDataDto();
+        imageDataDto.setContent(new byte[] { 'a', 'b' });
+        imageDataDto.setFilename("filename.png");
+
+        Mockito.when(gameImageService.download(ArgumentMatchers.anyLong(), ArgumentMatchers.eq(GameImageSize.SMALL)))
+                .thenReturn(imageDataDto);
+
+        // Act
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/1/images/small")
+                .accept(MediaType.APPLICATION_OCTET_STREAM_VALUE));
+
+        // Assert
+        resultActions
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    void findGameImageByGameIdAndImageSizeMedium_withValidId_returns200() throws Exception {
+        // Arrange
+        ImageDataDto imageDataDto = new ImageDataDto();
+        imageDataDto.setContent(new byte[] { 'a', 'b' });
+        imageDataDto.setFilename("filename.png");
+
+        Mockito.when(gameImageService.download(ArgumentMatchers.anyLong(), ArgumentMatchers.eq(GameImageSize.MEDIUM)))
+                .thenReturn(imageDataDto);
+
+        // Act
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/1/images/medium")
+                .accept(MediaType.APPLICATION_OCTET_STREAM_VALUE));
+
+        // Assert
+        resultActions
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    void findGameImageByGameIdAndImageSizeLarge_withValidId_returns200() throws Exception {
+        // Arrange
+        ImageDataDto imageDataDto = new ImageDataDto();
+        imageDataDto.setContent(new byte[] { 'a', 'b' });
+        imageDataDto.setFilename("filename.png");
+
+        Mockito.when(gameImageService.download(ArgumentMatchers.anyLong(), ArgumentMatchers.eq(GameImageSize.LARGE)))
+                .thenReturn(imageDataDto);
+
+        // Act
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/1/images/large")
+                .accept(MediaType.APPLICATION_OCTET_STREAM_VALUE));
+
+        // Assert
+        resultActions
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+}

--- a/game-server/src/test/java/com/sparkystudios/traklibrary/game/server/utils/ResponseVerifier.java
+++ b/game-server/src/test/java/com/sparkystudios/traklibrary/game/server/utils/ResponseVerifier.java
@@ -46,7 +46,9 @@ public class ResponseVerifier {
                 .andExpect(MockMvcResultMatchers.jsonPath("$" + root + ".version", Matchers.is((int)gameDto.getVersion().longValue())))
                 .andExpect(MockMvcResultMatchers.jsonPath("$" + root + ".release_dates").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.self").exists())
-                .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.image").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.small_image").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.medium_image").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.large_image").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.platforms").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.genres").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.developers").exists())
@@ -76,7 +78,9 @@ public class ResponseVerifier {
                 .andExpect(MockMvcResultMatchers.jsonPath("$" + root + ".genres").hasJsonPath())
                 .andExpect(MockMvcResultMatchers.jsonPath("$" + root + ".release_dates").hasJsonPath())
                 .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.self").exists())
-                .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.image").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.small_image").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.medium_image").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.large_image").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.platforms").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.genres").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.developers").exists())
@@ -113,7 +117,9 @@ public class ResponseVerifier {
                 .andExpect(MockMvcResultMatchers.jsonPath("$" + root + ".version").hasJsonPath())
                 .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.game").exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.game_details").exists())
-                .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.image").exists());
+                .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.small_image").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.medium_image").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$" + root + "._links.large_image").exists());
     }
 
     public static void verifyGenreDto(String root, ResultActions resultActions, GenreDto genreDto) throws Exception {

--- a/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/GameImageService.java
+++ b/game-service/src/main/java/com/sparkystudios/traklibrary/game/service/GameImageService.java
@@ -1,6 +1,7 @@
 package com.sparkystudios.traklibrary.game.service;
 
 import com.sparkystudios.traklibrary.game.domain.GameImage;
+import com.sparkystudios.traklibrary.game.domain.GameImageSize;
 import com.sparkystudios.traklibrary.game.service.dto.GameDto;
 import com.sparkystudios.traklibrary.game.service.dto.ImageDataDto;
 import com.sparkystudios.traklibrary.game.service.exception.UploadFailedException;
@@ -23,17 +24,18 @@ public interface GameImageService {
      * will be thrown to the callee.
      *
      * @param gameId The ID of the {@link GameDto} to upload an image for.
+     * @param gameImageSize Which image size this image will be associated with.
      * @param multipartFile The image that is to be associated with the given {@link GameDto}.
      *
      * @throws UploadFailedException Thrown if image uploading fails.
      */
-    void upload(long gameId, MultipartFile multipartFile);
+    void upload(long gameId, GameImageSize gameImageSize, MultipartFile multipartFile);
 
     /**
      * Given the ID of a {@link GameDto}, this method will attempt to find the
-     * {@link GameImage} that is mapped to the given ID. If one is found, the method will
-     * invoke the image service to return the byte data of the given image file that is associated with the
-     * {@link GameImage} and return the byte data with additional information wrapped in
+     * {@link GameImage} that is mapped to the given ID with the specified {@link GameImageSize}. If one is found,
+     * the method will invoke the image service to return the byte data of the given image file that is
+     * associated with the {@link GameImage} and return the byte data with additional information wrapped in
      * a {@link ImageDataDto} object.
      *
      * If the download of the image data fails, an {@link ImageDataDto} is still returned, but the {@link ImageDataDto#getContent()}
@@ -43,5 +45,5 @@ public interface GameImageService {
      *
      * @return An {@link ImageDataDto} object that contains the image information for the given {@link GameDto}.
      */
-    ImageDataDto download(long gameId);
+    ImageDataDto download(long gameId, GameImageSize gameImageSize);
 }

--- a/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/impl/GameImageServiceImplTest.java
+++ b/game-service/src/test/java/com/sparkystudios/traklibrary/game/service/impl/GameImageServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.sparkystudios.traklibrary.game.service.impl;
 
 import com.sparkystudios.traklibrary.game.domain.GameImage;
+import com.sparkystudios.traklibrary.game.domain.GameImageSize;
 import com.sparkystudios.traklibrary.game.repository.GameImageRepository;
 import com.sparkystudios.traklibrary.game.service.client.ImageClient;
 import com.sparkystudios.traklibrary.game.service.dto.ImageDataDto;
@@ -38,7 +39,7 @@ class GameImageServiceImplTest {
     @Test
     void upload_withExistingGameImage_throwsEntityExistsException() {
         // Arrange
-        Mockito.when(gameImageRepository.existsByGameId(ArgumentMatchers.anyLong()))
+        Mockito.when(gameImageRepository.existsByGameIdAndImageSize(ArgumentMatchers.anyLong(), ArgumentMatchers.any()))
                 .thenReturn(true);
 
         Mockito.when(messageSource.getMessage(ArgumentMatchers.anyString(), ArgumentMatchers.any(Object[].class), ArgumentMatchers.any(Locale.class)))
@@ -47,13 +48,14 @@ class GameImageServiceImplTest {
         MultipartFile multipartFile = Mockito.mock(MultipartFile.class);
 
         // Assert
-        Assertions.assertThrows(EntityExistsException.class, () -> gameImageService.upload(0L, multipartFile));
+        Assertions.assertThrows(EntityExistsException.class,
+                () -> gameImageService.upload(0L, GameImageSize.SMALL, multipartFile));
     }
 
     @Test
     void upload_withNewGameImage_invokesSaveAndImageClientUpload() {
         // Arrange
-        Mockito.when(gameImageRepository.existsByGameId(ArgumentMatchers.anyLong()))
+        Mockito.when(gameImageRepository.existsByGameIdAndImageSize(ArgumentMatchers.anyLong(), ArgumentMatchers.any()))
                 .thenReturn(false);
 
         MultipartFile multipartFile = Mockito.mock(MultipartFile.class);
@@ -67,7 +69,7 @@ class GameImageServiceImplTest {
                 .uploadGameImage(ArgumentMatchers.any(), ArgumentMatchers.anyLong());
 
         // Act
-        gameImageService.upload(0L, multipartFile);
+        gameImageService.upload(0L, GameImageSize.MEDIUM, multipartFile);
 
         // Assert
         Mockito.verify(gameImageRepository, Mockito.atMostOnce())
@@ -80,14 +82,14 @@ class GameImageServiceImplTest {
     @Test
     void download_withNonExistentGameImage_throwsEntityNotFoundException() {
         // Arrange
-        Mockito.when(gameImageRepository.findByGameId(ArgumentMatchers.anyLong()))
+        Mockito.when(gameImageRepository.findByGameIdAndImageSize(ArgumentMatchers.anyLong(), ArgumentMatchers.any()))
                 .thenReturn(Optional.empty());
 
         Mockito.when(messageSource.getMessage(ArgumentMatchers.anyString(), ArgumentMatchers.any(Object[].class), ArgumentMatchers.any(Locale.class)))
                 .thenReturn("");
 
         // Assert
-        Assertions.assertThrows(EntityNotFoundException.class, () -> gameImageService.download(0L));
+        Assertions.assertThrows(EntityNotFoundException.class, () -> gameImageService.download(0L, GameImageSize.MEDIUM));
     }
 
     @Test
@@ -98,14 +100,14 @@ class GameImageServiceImplTest {
         GameImage gameImage = new GameImage();
         gameImage.setFilename("filename.txt");
 
-        Mockito.when(gameImageRepository.findByGameId(ArgumentMatchers.anyLong()))
+        Mockito.when(gameImageRepository.findByGameIdAndImageSize(ArgumentMatchers.anyLong(), ArgumentMatchers.any()))
                 .thenReturn(Optional.of(gameImage));
 
         Mockito.when(imageClient.downloadGameImage(ArgumentMatchers.anyString(), ArgumentMatchers.anyLong()))
                 .thenReturn(imageData);
 
         // Act
-        ImageDataDto imageDataDto = gameImageService.download(0L);
+        ImageDataDto imageDataDto = gameImageService.download(0L, GameImageSize.MEDIUM);
 
         // Assert
         Mockito.verify(imageClient, Mockito.atMostOnce())

--- a/gateway-server/src/main/java/com/sparkystudios/traklibrary/gateway/server/config/SecurityConfig.java
+++ b/gateway-server/src/main/java/com/sparkystudios/traklibrary/gateway/server/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
                 .pathMatchers(HttpMethod.POST, "/auth/token", "/auth/token/**", "/auth/users").permitAll()
                 .pathMatchers(HttpMethod.PUT, "/auth/users", "/auth/users/recover").permitAll()
                 .pathMatchers(HttpMethod.GET, "/images/**").permitAll()
-                .pathMatchers(HttpMethod.GET, "/games/*/image").permitAll()
+                .pathMatchers(HttpMethod.GET, "/games/*/images/small", "/games/*/images/medium", "/games/*/images/large").permitAll()
                 .anyExchange()
                 .authenticated()
                 .and()


### PR DESCRIPTION
- Updated the postgresql DB version from 9.6 to the latest supported version (13.2).
- Added a new column to the game_image table, which allows for up to three images for a single game (small, medium and large) which is defined by the new size column.
- Changed the GameImageRepository to use the new GameImageSize enum for retrieving different images for the DB.
- Split out the implementation for game images from the GameController to its own GameImageController.
- Ensured the new end-points are passed through the security filters.
- Added/updated unit tests for new functionality.
-